### PR TITLE
refactor: replace typescript-eslint config with ESLint defineConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Then add the following code to your local `.oxlintrc.json` file:
 And the following code to `eslint.config.js` file:
 
 ```js
-import tsEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import { configs } from 'eslint-config-greenpie';
 
-export default tsEslint.config(
+export default defineConfig(
   ...configs.default,
   ...configs.vue
 );

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,10 +1,10 @@
 /* eslint-disable @stylistic/line-comment-position */
 /* eslint-disable no-inline-comments */
 import eslintJs from '@eslint/js';
-import tsEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 
 // oxlint-disable-next-line no-default-export
-export default tsEslint.config(
+export default defineConfig(
   eslintJs.configs.recommended,
 
   {
@@ -154,6 +154,7 @@ export default tsEslint.config(
       'prefer-promise-reject-errors': 'off',
       'prefer-rest-params': 'off',
       'prefer-spread': 'off',
+      'prefer-template': 'off',
       'require-await': 'off',
       'require-yield': 'off',
       'sort-imports': 'off',
@@ -249,7 +250,6 @@ export default tsEslint.config(
       'prefer-const': 'error',
       'prefer-named-capture-group': 'error',
       'prefer-regex-literals': 'error',
-      'prefer-template': 'error',
       'require-unicode-regexp': 'error',
       strict: 'error'
     }

--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -9,7 +9,8 @@
     "promise",
     "typescript",
     "unicorn",
-    "vitest"
+    "vitest",
+    "vue"
   ],
 
   "categories": {
@@ -22,6 +23,8 @@
     "suspicious": "off"
   },
 
+  // Releases: https://github.com/oxc-project/oxc/releases
+  // Rules: https://oxc.rs/docs/guide/usage/linter/rules.html
   "rules": {
     /**
      * Correctness rules
@@ -158,6 +161,10 @@
 
     "vitest/no-conditional-tests": "error",
     "vitest/require-local-test-context-for-concurrent-snapshots": "error",
+
+    // Vue
+
+    "vue/valid-define-emits": "error",
 
     /**
      * Perf rules
@@ -299,6 +306,7 @@
 
     // Promise
 
+    "promise/always-return": "error",
     "promise/no-promise-in-callback": "error",
 
     // TypeScript
@@ -436,7 +444,10 @@
       "allowArrowFunctions": true
     }],
 
-    "eslint/grouped-accessor-pairs": "error",
+    "eslint/grouped-accessor-pairs": ["error", {
+      "enforceForTSTypes": true
+    }],
+
     "eslint/guard-for-in": "error",
 
     "eslint/id-length": ["error", {
@@ -477,6 +488,7 @@
     "eslint/prefer-promise-reject-errors": "error",
     "eslint/prefer-rest-params": "error",
     "eslint/prefer-spread": "error",
+    "eslint/prefer-template": "error",
 
     "eslint/sort-imports": ["error", {
       "ignoreDeclarationSort": true,

--- a/configs/stylistic.js
+++ b/configs/stylistic.js
@@ -1,10 +1,10 @@
 import stylisticPlugin from '@stylistic/eslint-plugin';
-import tsEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 
 // https://eslint.style/packages/js
 
 // oxlint-disable-next-line no-default-export
-export default tsEslint.config({
+export default defineConfig({
   plugins: {
     '@stylistic': stylisticPlugin
   },
@@ -39,26 +39,6 @@ export default tsEslint.config({
     '@stylistic/implicit-arrow-linebreak': 'error',
     '@stylistic/indent': ['error', 2],
     '@stylistic/indent-binary-ops': ['error', 2],
-    '@stylistic/jsx-child-element-spacing': 'error',
-    '@stylistic/jsx-closing-bracket-location': 'error',
-    '@stylistic/jsx-closing-tag-location': 'error',
-    '@stylistic/jsx-curly-brace-presence': 'error',
-    '@stylistic/jsx-curly-newline': 'error',
-    '@stylistic/jsx-curly-spacing': 'error',
-    '@stylistic/jsx-equals-spacing': 'error',
-    '@stylistic/jsx-first-prop-new-line': 'error',
-    '@stylistic/jsx-function-call-newline': 'error',
-    '@stylistic/jsx-indent-props': ['error', 2],
-    '@stylistic/jsx-max-props-per-line': 'error',
-    '@stylistic/jsx-newline': 'error',
-    '@stylistic/jsx-one-expression-per-line': 'error',
-    '@stylistic/jsx-pascal-case': 'error',
-    '@stylistic/jsx-props-no-multi-spaces': 'error',
-    '@stylistic/jsx-quotes': 'error',
-    '@stylistic/jsx-self-closing-comp': 'error',
-    '@stylistic/jsx-sort-props': 'error',
-    '@stylistic/jsx-tag-spacing': 'error',
-    '@stylistic/jsx-wrap-multilines': 'error',
     '@stylistic/key-spacing': 'error',
     '@stylistic/keyword-spacing': 'error',
     '@stylistic/line-comment-position': 'error',

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,7 +1,8 @@
 import tsEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 
 // oxlint-disable-next-line no-default-export
-export default tsEslint.config({
+export default defineConfig({
   plugins: {
     '@typescript-eslint': tsEslint.plugin
   },

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -1,5 +1,5 @@
-import tsEslint from 'typescript-eslint';
 import vuePlugin from 'eslint-plugin-vue';
+import { defineConfig } from 'eslint/config';
 
 /*
  * https://eslint.vuejs.org/
@@ -7,7 +7,7 @@ import vuePlugin from 'eslint-plugin-vue';
  */
 
 // oxlint-disable-next-line no-default-export
-export default tsEslint.config(
+export default defineConfig(
   ...vuePlugin.configs['flat/base'],
 
   {
@@ -19,6 +19,9 @@ export default tsEslint.config(
     },
 
     rules: {
+      // Disabled in favor of oxlint rules
+      'vue/valid-define-emits': 'off',
+
       // Disable some rules from other configs
 
       'consistent-return': 'off',
@@ -70,7 +73,6 @@ export default tsEslint.config(
       'vue/return-in-emits-validator': 'error',
       'vue/use-v-on-exact': 'error',
       'vue/valid-attribute-name': 'error',
-      'vue/valid-define-emits': 'error',
       'vue/valid-define-props': 'error',
       'vue/valid-next-tick': 'error',
       'vue/valid-template-root': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
-import tsEslint from 'typescript-eslint';
 import { configs } from './index.js';
+import { defineConfig } from 'eslint/config';
 
 // oxlint-disable-next-line no-default-export
-export default tsEslint.config(
+export default defineConfig(
   ...configs.default,
   ...configs.vue
 );

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-import tsEslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 import baseConfig from './configs/base.js';
 import stylistic from './configs/stylistic.js';
 import typeScript from './configs/typescript.js';
 import vue from './configs/vue.js';
 
-const jsConfig = tsEslint.config({
+const jsConfig = defineConfig({
   files: [
     '**/*.{js,mjs,cjs}'
   ],
@@ -15,7 +15,7 @@ const jsConfig = tsEslint.config({
   ]
 });
 
-const tsConfig = tsEslint.config({
+const tsConfig = defineConfig({
   files: [
     '**/*.{ts,mts,cts}'
   ],
@@ -27,7 +27,7 @@ const tsConfig = tsEslint.config({
   ]
 });
 
-const vueConfig = tsEslint.config({
+const vueConfig = defineConfig({
   files: [
     '**/*.vue'
   ],
@@ -40,7 +40,7 @@ const vueConfig = tsEslint.config({
   ]
 });
 
-const defaultConfig = tsEslint.config(
+const defaultConfig = defineConfig(
   ...jsConfig,
   ...tsConfig
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "14.1.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.11.2"
+        "oxlint": "^1.14.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.2.2",
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
-      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -171,31 +171,17 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -264,94 +250,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@oxlint-tsgolint/darwin-arm64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.0.2.tgz",
-      "integrity": "sha512-LH6tDgvQkF7ui+lNuRjJeaJTdYCfxMXI0j8YTbbLVSHz42EI5DTJDtngsCd2dSlUfKAJqaehECKccqcJ3yueHQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oxlint-tsgolint/darwin-x64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.0.2.tgz",
-      "integrity": "sha512-VEUXK5h4ZyCM3O++dK7A+IcqwqWv8zfRKyM1vgcIrnQXtwvbs9KFyK6I0BSnMBCV9be67b9Gl7TDeSS8jBchpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oxlint-tsgolint/linux-arm64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.0.2.tgz",
-      "integrity": "sha512-A/NtWuq+u+Y6oAo7p6D18rmkckHL/nx0GrqlZvfHAWOJYXXLanLX0QozPPDoSH8zRwHc7W7t95JU8awS7Krp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxlint-tsgolint/linux-x64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.0.2.tgz",
-      "integrity": "sha512-p42pKfILRhm/cE8Y5BgXlQpM22Q+Olhy9A60VvOW0epu/Vr/FtUa/MbZJ2wGRuAKSm8oW9JhgjIj5laSWAX8vg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxlint-tsgolint/win32-arm64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.0.2.tgz",
-      "integrity": "sha512-LTKCeeKZRd4vT+C3y7d0KEYqAzIiLvf/189H6ispKtfyKeQKxOGU+XG9xRP4GovPvZOYL6fIsVxe09BUaNuDnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@oxlint-tsgolint/win32-x64": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.0.2.tgz",
-      "integrity": "sha512-SdrPYSkBHd43WY5h78ICLVS851/379pzIjUVM1LDltZuAgv209H8f1/g5cdX4gY46RDvV86guLh+PbfMHHugog==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.11.2.tgz",
-      "integrity": "sha512-eJZ1VKaS9qj44FTus3qTu790xMnJ/GViJcoVF3zNux5m3lOiWhwJB149+P7a7LcTowNdc26i1DmwcWxUllPwZw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.14.0.tgz",
+      "integrity": "sha512-rcTw0QWeOc6IeVp+Up7WtcwdS9l4j7TOq4tihF0Ud/fl+VUVdvDCPuZ9QTnLXJhwMXiyQRWdxRyI6XBwf80ncQ==",
       "cpu": [
         "arm64"
       ],
@@ -363,9 +265,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.11.2.tgz",
-      "integrity": "sha512-KH9BJ5ObkReIr00IbGaImqL2q4CCjIAk9HxgULvWpjSnqUL7OgJFZAabb9Z5ZS0+RyZrKUtd1ZU/Ackb6k4G3Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.14.0.tgz",
+      "integrity": "sha512-TWFSEmyl2/DN4HoXNwQl0y/y3EXFJDctfv5MiDtVOV1GJKX80cGSIxMxXb08Q3CCWqteqEijmfSMo5TG8X1H/A==",
       "cpu": [
         "x64"
       ],
@@ -377,9 +279,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.11.2.tgz",
-      "integrity": "sha512-nIhyGApnEuqLazaSwvEkg5pMm2rlBPJccAGrNmJPcMukKbD5fUYyuCvkm9CFUqTm1+MIYrs5bTeRhnDSEa2mYw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.14.0.tgz",
+      "integrity": "sha512-N1FqdKfwhVWPpMElv8qlGqdEefTbDYaRVhdGWOjs/2f7FESa5vX0cvA7ToqzkoXyXZI5DqByWiPML33njK30Kg==",
       "cpu": [
         "arm64"
       ],
@@ -391,9 +293,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.11.2.tgz",
-      "integrity": "sha512-ifrqaBwVYt3g6GUbIwF9G9pTvkIvbs47F47oSjVogdy5hn2yEEi1zxyYGV9AFF3zVMgp2xDIO8G/gTuz1WPHkg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.14.0.tgz",
+      "integrity": "sha512-v/BPuiateLBb7Gz1STb69EWjkgKdlPQ1NM56z+QQur21ly2hiMkBX2n0zEhqfu9PQVRUizu6AlsYuzcPY/zsIQ==",
       "cpu": [
         "arm64"
       ],
@@ -405,9 +307,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.11.2.tgz",
-      "integrity": "sha512-yWCgoOQ0xA/AxJ7ruLMR/YMKYEwV048vrWftZGCjKPYgZeZe9bpghAoRlLi6qjw7ReNpctk9Ho+l35TYXNqhzA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.14.0.tgz",
+      "integrity": "sha512-gUTp8KIrSYt97dn+tRRC3LKnH4xlHKCwrPwiDcGmLbCxojuN9/H5mnIhPKEfwNuZNdoKGS/ABuq3neVyvRCRtQ==",
       "cpu": [
         "x64"
       ],
@@ -419,9 +321,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.11.2.tgz",
-      "integrity": "sha512-nYer9TaY/gC+kVwOfb9DxZh0dNdqFI8ax/MD9TwH8p3ZnWuUe1Ocfpg0V94tuPoGxHFqcXU7GRD1cTvREHfcTg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.14.0.tgz",
+      "integrity": "sha512-DpN6cW2HPjYXeENG0JBbmubO8LtfKt6qJqEMBw9gUevbyBaX+k+Jn7sYgh6S23wGOkzmTNphBsf/7ulj4nIVYA==",
       "cpu": [
         "x64"
       ],
@@ -433,9 +335,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.11.2.tgz",
-      "integrity": "sha512-zbfZ7r68MyxQ2GAg/jFzIQCFrL8lcwnxfIEqY+V16/Xcd1rZVfMH3PwJMloib26pOLH6/RUlC5IjdVo8icadHA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.14.0.tgz",
+      "integrity": "sha512-oXxJksnUTUMgJ0NvjKS1mrCXAy1ttPgIVacRSlxQ+1XHy+aJDMM7I8fsCtoKoEcTIpPaD98eqUqlLYs0H2MGjA==",
       "cpu": [
         "arm64"
       ],
@@ -447,9 +349,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.11.2.tgz",
-      "integrity": "sha512-eSATaCIUwdh+t9gu9xoETjh+0PYwjVSLtnZ20XakKNjvee4KmQbWXCxXyA1vz1E0qxiUX/fYqsaOHueIwQ2LVA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.14.0.tgz",
+      "integrity": "sha512-iRYy2rhTQKFztyx0jtNMRBnFpzsRwFdjWQ7sKKzJpmbijA3Tw3DCqlGT7QRgoVRF0+X/ccNGvvsrgMohPVfLeQ==",
       "cpu": [
         "x64"
       ],
@@ -461,14 +363,14 @@
       ]
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.3.tgz",
-      "integrity": "sha512-oY7GVkJGVMI5benlBDCaRrSC1qPasafyv5dOBLLv5MTilMGnErKhO6ziEfodDDIZbo5QxPUNW360VudJOFODMw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
+      "integrity": "sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/types": "^8.38.0",
+        "@typescript-eslint/types": "^8.41.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -496,17 +398,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
-      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
+      "integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/type-utils": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/type-utils": "8.43.0",
+        "@typescript-eslint/utils": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -520,7 +422,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.39.1",
+        "@typescript-eslint/parser": "^8.43.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -536,16 +438,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
-      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
+      "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -561,14 +463,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
-      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
+      "integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.1",
-        "@typescript-eslint/types": "^8.39.1",
+        "@typescript-eslint/tsconfig-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -583,14 +485,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
-      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
+      "integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1"
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -601,9 +503,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
-      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
+      "integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -618,15 +520,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
-      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
+      "integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0",
+        "@typescript-eslint/utils": "8.43.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -643,9 +545,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
-      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
+      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -657,16 +559,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
-      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
+      "integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.1",
-        "@typescript-eslint/tsconfig-utils": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/visitor-keys": "8.39.1",
+        "@typescript-eslint/project-service": "8.43.0",
+        "@typescript-eslint/tsconfig-utils": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -712,16 +614,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
-      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
+      "integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.39.1",
-        "@typescript-eslint/types": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1"
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -736,13 +638,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
-      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
+      "integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/types": "8.43.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -975,19 +877,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
-      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.33.0",
+        "@eslint/js": "9.35.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1579,9 +1481,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.11.2.tgz",
-      "integrity": "sha512-/MDUxbel5vrwxWgiGU6hZzhDiTv0TUlyZak+WP+SaTO709du+6F07zCDvYj5lgkAnEcFbdrUlA67HEnleGR0Zw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.14.0.tgz",
+      "integrity": "sha512-oo0nq3zF9hmgATGc9esoMahLuEESOodUxEDeHDA2K7tbYcSfcmReE9G2QNppnq9rOSQHLTwlMtzGAjjttYaufQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1595,34 +1497,22 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.11.2",
-        "@oxlint/darwin-x64": "1.11.2",
-        "@oxlint/linux-arm64-gnu": "1.11.2",
-        "@oxlint/linux-arm64-musl": "1.11.2",
-        "@oxlint/linux-x64-gnu": "1.11.2",
-        "@oxlint/linux-x64-musl": "1.11.2",
-        "@oxlint/win32-arm64": "1.11.2",
-        "@oxlint/win32-x64": "1.11.2",
-        "oxlint-tsgolint": ">=0.0.1"
-      }
-    },
-    "node_modules/oxlint-tsgolint": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.0.2.tgz",
-      "integrity": "sha512-afl7YXlHyiLb7YxL6ixAQ/1JLBy52vzk07+fTT53tPdyUZPpbkJz1CJMGNLteaX1t+vDq6wXdCj4xTO2jcViGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "tsgolint": "bin/tsgolint.js"
+        "@oxlint/darwin-arm64": "1.14.0",
+        "@oxlint/darwin-x64": "1.14.0",
+        "@oxlint/linux-arm64-gnu": "1.14.0",
+        "@oxlint/linux-arm64-musl": "1.14.0",
+        "@oxlint/linux-x64-gnu": "1.14.0",
+        "@oxlint/linux-x64-musl": "1.14.0",
+        "@oxlint/win32-arm64": "1.14.0",
+        "@oxlint/win32-x64": "1.14.0"
       },
-      "optionalDependencies": {
-        "@oxlint-tsgolint/darwin-arm64": "0.0.2",
-        "@oxlint-tsgolint/darwin-x64": "0.0.2",
-        "@oxlint-tsgolint/linux-arm64": "0.0.2",
-        "@oxlint-tsgolint/linux-x64": "0.0.2",
-        "@oxlint-tsgolint/win32-arm64": "0.0.2",
-        "@oxlint-tsgolint/win32-x64": "0.0.2"
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.1.5"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -1919,16 +1809,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.39.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.1.tgz",
-      "integrity": "sha512-GDUv6/NDYngUlNvwaHM1RamYftxf782IyEDbdj3SeaIHHv8fNQVRC++fITT7kUJV/5rIA/tkoRSSskt6osEfqg==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.43.0.tgz",
+      "integrity": "sha512-FyRGJKUGvcFekRRcBKFBlAhnp4Ng8rhe8tuvvkR9OiU0gfd4vyvTRQHEckO6VDlH57jbeUQem2IpqPq9kLJH+w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.1",
-        "@typescript-eslint/parser": "8.39.1",
-        "@typescript-eslint/typescript-estree": "8.39.1",
-        "@typescript-eslint/utils": "8.39.1"
+        "@typescript-eslint/eslint-plugin": "8.43.0",
+        "@typescript-eslint/parser": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0",
+        "@typescript-eslint/utils": "8.43.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.11.2"
+    "oxlint": "^1.14.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.2.2",


### PR DESCRIPTION
- ♻️ Replace tsEslint.config() with defineConfig() across all config files
- 🔧 Migrate from typescript-eslint config helper to native ESLint config
- 📦 Update oxlint from v1.11.2 → v1.14.0
- ✨ Add vue plugin and rules to oxlint configuration
- 📚 Update README examples to use defineConfig pattern
- 🎨 Remove JSX stylistic rules from stylistic config
- 🔧 Move prefer-template rule from base to oxlint config