### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,27 +10,28 @@
       "license": "MIT",
       "devDependencies": {
         "oxlint": "^1.16.0",
-        "taze": "^19.6.0"
+        "taze": "^19.7.0"
       },
       "peerDependencies": {
-        "@stylistic/eslint-plugin": "^5.3.1",
-        "eslint": "^9.35.0",
-        "eslint-plugin-vue": "^10.4.0",
+        "@stylistic/eslint-plugin": "^5.4.0",
+        "eslint": "^9.36.0",
+        "eslint-plugin-vue": "^10.5.0",
         "oxlint": "^1.16.0",
-        "typescript-eslint": "^8.44.0"
+        "typescript-eslint": "^8.44.1"
       }
     },
     "node_modules/@antfu/ni": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
-      "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-26.0.1.tgz",
+      "integrity": "sha512-yGtjrmEVziDXW/7ggkzDtJkiJ8e8a9j+CtYBhT6gnvVoIXHtTc+iL+ZDMfUDe1wxRvYJrLpmHLJb5HjA5Hskyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansis": "^4.0.0",
+        "ansis": "^4.1.0",
         "fzf": "^0.5.2",
         "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.0.1",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "na": "bin/na.mjs",
@@ -40,6 +41,9 @@
         "nr": "bin/nr.mjs",
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -147,9 +151,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -399,14 +403,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
-      "integrity": "sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
+      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/types": "^8.41.0",
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@typescript-eslint/types": "^8.44.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -434,17 +438,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
-      "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/type-utils": "8.44.0",
-        "@typescript-eslint/utils": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -458,7 +462,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.44.0",
+        "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -474,16 +478,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
-      "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -499,14 +503,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
-      "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -521,14 +525,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
-      "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0"
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -539,9 +543,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
-      "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -556,15 +560,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
-      "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/utils": "8.44.0",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -581,9 +585,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
-      "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -595,16 +599,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
-      "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.44.0",
-        "@typescript-eslint/tsconfig-utils": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/visitor-keys": "8.44.0",
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -650,16 +654,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
-      "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.44.0",
-        "@typescript-eslint/types": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0"
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -674,13 +678,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
-      "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/types": "8.44.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -947,9 +951,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -959,7 +963,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1008,9 +1012,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.4.0.tgz",
-      "integrity": "sha512-K6tP0dW8FJVZLQxa2S7LcE1lLw3X8VvB3t887Q6CLrFVxHYBXGANbXvwNzYIu6Ughx1bSJ5BDT0YB3ybPT39lw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.5.0.tgz",
+      "integrity": "sha512-7BZHsG3kC2vei8F2W8hnfDi9RK+cv5eKPMvzBdrl8Vuc0hR5odGQRli8VVzUkrmUHkxFEm4Iio1r5HOKslO0Aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1025,11 +1029,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "vue-eslint-parser": "^10.0.0"
       },
       "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
         "@typescript-eslint/parser": {
           "optional": true
         }
@@ -1413,9 +1421,9 @@
       "peer": true
     },
     "node_modules/jiti": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
-      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
+      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -2002,13 +2010,13 @@
       }
     },
     "node_modules/taze": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/taze/-/taze-19.6.0.tgz",
-      "integrity": "sha512-hQGQH4WVtV9BqsZbrGzOmOP4NdWqie948BnqtH+NPwdVt5mI+qALVRDvgzgdf+neN7bcrVVpV4ToyFkxg0U0xQ==",
+      "version": "19.7.0",
+      "resolved": "https://registry.npmjs.org/taze/-/taze-19.7.0.tgz",
+      "integrity": "sha512-+iQhlg/O0XLTYvJFpyTq8MiXBlZx6IWPOUeMHm/abE971LW4REA7IgQSCqyi9Cd9WPziL0J8IiHQhpJd5Z0PpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@antfu/ni": "^25.0.0",
+        "@antfu/ni": "^26.0.1",
         "cac": "^6.7.14",
         "find-up-simple": "^1.0.1",
         "ofetch": "^1.4.1",
@@ -2017,9 +2025,8 @@
         "pnpm-workspace-yaml": "^1.1.1",
         "restore-cursor": "^5.1.0",
         "tinyexec": "^1.0.1",
-        "tinyglobby": "^0.2.14",
-        "unconfig": "^7.3.3",
-        "yaml": "^2.8.1"
+        "tinyglobby": "^0.2.15",
+        "unconfig": "^7.3.3"
       },
       "bin": {
         "taze": "bin/taze.mjs"
@@ -2106,16 +2113,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.0.tgz",
-      "integrity": "sha512-ib7mCkYuIzYonCq9XWF5XNw+fkj2zg629PSa9KNIQ47RXFF763S5BIX4wqz1+FLPogTZoiw8KmCiRPRa8bL3qw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
+      "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.44.0",
-        "@typescript-eslint/parser": "8.44.0",
-        "@typescript-eslint/typescript-estree": "8.44.0",
-        "@typescript-eslint/utils": "8.44.0"
+        "@typescript-eslint/eslint-plugin": "8.44.1",
+        "@typescript-eslint/parser": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   ],
   "devDependencies": {
     "oxlint": "^1.16.0",
-    "taze": "^19.6.0"
+    "taze": "^19.7.0"
   },
   "peerDependencies": {
-    "@stylistic/eslint-plugin": "^5.3.1",
-    "eslint": "^9.35.0",
-    "eslint-plugin-vue": "^10.4.0",
+    "@stylistic/eslint-plugin": "^5.4.0",
+    "eslint": "^9.36.0",
+    "eslint-plugin-vue": "^10.5.0",
     "oxlint": "^1.16.0",
-    "typescript-eslint": "^8.44.0"
+    "typescript-eslint": "^8.44.1"
   }
 }


### PR DESCRIPTION
## 📦 Dependencies Update

This PR updates several peer dependencies and dev dependencies to their latest versions:

### Updated packages:
- 📦 `taze`: ^19.6.0 -> ^19.7.0
- 📦 `@stylistic/eslint-plugin`: ^5.3.1 -> ^5.4.0  
- 📦 `eslint`: ^9.35.0 -> ^9.36.0
- 📦 `eslint-plugin-vue`: ^10.4.0 -> ^10.5.0
- 📦 `typescript-eslint`: ^8.44.0 -> ^8.44.1

### Changes summary:
- ⬆️ Updated peer dependencies to ensure compatibility with latest ESLint ecosystem
- 🔧 Updated dev dependency `taze` for better dependency management
- 🚀 No breaking changes expected as all updates are minor/patch versions