### PR TITLE
chore: update oxlint to v1.17.0 with rule migrations

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -93,6 +93,7 @@ export default defineConfig(
       'no-lonely-if': 'off',
       'no-loss-of-precision': 'off',
       'no-magic-numbers': 'off',
+      'no-misleading-character-class': 'off',
       'no-multi-assign': 'off',
       'no-multi-str': 'off',
       'no-negated-condition': 'off',
@@ -179,7 +180,6 @@ export default defineConfig(
        */
 
       'constructor-super': 'error',
-      'no-misleading-character-class': 'error',
       'no-promise-executor-return': 'error',
       'no-unmodified-loop-condition': 'error',
       'no-unreachable-loop': 'error',

--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -330,6 +330,9 @@
     "unicorn/prefer-add-event-listener": "error",
     "unicorn/require-post-message-target-origin": "error",
 
+    // Vue
+    "vue/no-required-prop-with-default": "error",
+
     /**
      * Pedantic rules
      */
@@ -591,6 +594,7 @@
     // Vue
     "vue/define-emits-declaration": "error",
     "vue/define-props-declaration": "error",
+    "vue/require-typed-ref": "error",
 
     /**
      * Nursery rules
@@ -599,6 +603,7 @@
     // ESLint
 
     "eslint/getter-return": "error",
+    "eslint/no-misleading-character-class": "error",
     "eslint/no-undef": "error",
     "eslint/no-unreachable": "error",
 

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -23,6 +23,8 @@ export default defineConfig(
       'vue/define-emits-declaration': 'off',
       'vue/define-props-declaration': 'off',
       'vue/no-multiple-slot-args': 'off',
+      'vue/no-required-prop-with-default': 'off',
+      'vue/require-typed-ref': 'off',
       'vue/valid-define-emits': 'off',
       'vue/valid-define-props': 'off',
 
@@ -246,7 +248,6 @@ export default defineConfig(
       'vue/no-negated-v-if-condition': 'error',
       'vue/no-potential-component-option-typo': 'error',
       'vue/no-ref-object-reactivity-loss': 'error',
-      'vue/no-required-prop-with-default': 'error',
       'vue/no-restricted-block': 'error',
       'vue/no-restricted-call-after-await': 'error',
       'vue/no-restricted-class': 'error',
@@ -294,7 +295,6 @@ export default defineConfig(
       'vue/require-name-property': 'error',
       'vue/require-prop-comment': 'off',
       'vue/require-typed-object-prop': 'error',
-      'vue/require-typed-ref': 'error',
 
       'vue/script-indent': ['error', 2, {
         baseIndent: 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "14.2.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.16.0",
+        "oxlint": "^1.17.0",
         "taze": "^19.7.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
         "eslint": "^9.36.0",
         "eslint-plugin-vue": "^10.5.0",
-        "oxlint": "^1.16.0",
+        "oxlint": "^1.17.0",
         "typescript-eslint": "^8.44.1"
       }
     },
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.16.0.tgz",
-      "integrity": "sha512-t9sBjbcG15Jgwgw2wY+rtfKEazdkKM/YhcdyjmGYeSjBXaczLfp/gZe03taC2qUHK+t6cxSYNkOLXRLWxaf3tw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.17.0.tgz",
+      "integrity": "sha512-mVYPFmwUfV0ZNFSKlQtAniKxY9yuTa2p9JrtEwMh5B+vyoRuhjsCl0Z1uEhry+Se5pbh4WHxNP2sJVhuta6P4w==",
       "cpu": [
         "arm64"
       ],
@@ -292,9 +292,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.16.0.tgz",
-      "integrity": "sha512-c9aeLQATeu27TK8gR/p8GfRBsuakx0zs+6UHFq/s8Kux+8tYb3pH1pql/XWUPbxubv48F2MpnD5zgjOrShAgag==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.17.0.tgz",
+      "integrity": "sha512-5+oE0tT0IFdHdosLnOibbTBpVhjTaPfdveWc988ooZ4ap8YdAeB6heizhtm1dNa3RZ5rKucZ4SIlNYsh0f9MLw==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +306,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.16.0.tgz",
-      "integrity": "sha512-ZoBtxtRHhftbiKKeScpgUKIg4cu9s7rsBPCkjfMCY0uLjhKqm6ShPEaIuP8515+/Csouciz1ViZhbrya5ligAg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.17.0.tgz",
+      "integrity": "sha512-ljewxrwJzz62sHXLwgJagCtgkPnJ5oAteOaZoZ306QmANkNubkRGx9d1a/SEvl0D6obffVH23pZxETt6oyPQvQ==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +320,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.16.0.tgz",
-      "integrity": "sha512-a/Dys7CTyj1eZIkD59k9Y3lp5YsHBUeZXR7qHTplKb41H+Ivm5OQPf+rfbCBSLMfCPZCeKQPW36GXOSYLNE1uw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.17.0.tgz",
+      "integrity": "sha512-U1h/0lSXAGdXpMLaJsTF0+CdxcHgd2Rh2Ky8jyOVQ/pCtZahlWeQeUUkZ3CA7ANKpwymlh/iBmJzu1KZl1c2cQ==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +334,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.16.0.tgz",
-      "integrity": "sha512-rsfv90ytLhl+s7aa8eE8gGwB1XGbiUA2oyUee/RhGRyeoZoe9/hHNtIcE2XndMYlJToROKmGyrTN4MD2c0xxLQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.17.0.tgz",
+      "integrity": "sha512-38qpK/lfKHYskF5kzebe1I/aBKuAMbI+sCoUYajJIRlQkmHJ3VEXCUGhQj6qtprRVV/ECLlr6Eoo8fHy4jzdYA==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +348,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.16.0.tgz",
-      "integrity": "sha512-djwSL4harw46kdCwaORUvApyE9Y6JSnJ7pF5PHcQlJ7S1IusfjzYljXky4hONPO0otvXWdKq1GpJqhmtM0/xbg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.17.0.tgz",
+      "integrity": "sha512-pcQ27T+xK49d8SWa52N37y7BxyDG098QEDonkoJDMQ7YOqDegQ25Vrz56VSUhgtkrO25d8B7P2raH/J1PRsW5A==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +362,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.16.0.tgz",
-      "integrity": "sha512-lQBfW4hBiQ47P12UAFXyX3RVHlWCSYp6I89YhG+0zoLipxAfyB37P8G8N43T/fkUaleb8lvt0jyNG6jQTkCmhg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.17.0.tgz",
+      "integrity": "sha512-WEWf89vKYUYc8ODhyh6BFsvbTzzXZ0cCFMwy4l3mMHkLn5nS9wj7+4NrBB6OJ7tlPZbi57039F9UNpH7PvVEbw==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +376,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.16.0.tgz",
-      "integrity": "sha512-B5se3JnM4Xu6uHF78hAY9wdk/sdLFib1YwFsLY6rkQKEMFyi+vMZZlDaAS+s+Dt9q7q881U2OhNznZenJZdPdQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.17.0.tgz",
+      "integrity": "sha512-V6TxSg7JTRqzFrAGymatY3rhIFfH0kyNcTQKe5Od6BhReCBqf6WfGQ0TCGstz9XpGdmmg3lo3zD6/M7ud9aqOA==",
       "cpu": [
         "x64"
       ],
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.16.0.tgz",
-      "integrity": "sha512-o6z8s6QVw/d7QuxQ7QFfqDMrIcmHyU3J/MewxjqduJmy4vHt/s7OZISk8zEXjHXZzTWrcFakIrLqU/b9IKTcjg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.17.0.tgz",
+      "integrity": "sha512-pfafE/o4DDP0E9+AieMebdvgUTCGX5B3hxOqOUXjNapI5Q8DgBGIYHyYIEuwjkgwmMQpGJIaKLENE8/gwcZTKw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1665,20 +1665,20 @@
         "oxlint": "bin/oxlint"
       },
       "engines": {
-        "node": ">=8.*"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.16.0",
-        "@oxlint/darwin-x64": "1.16.0",
-        "@oxlint/linux-arm64-gnu": "1.16.0",
-        "@oxlint/linux-arm64-musl": "1.16.0",
-        "@oxlint/linux-x64-gnu": "1.16.0",
-        "@oxlint/linux-x64-musl": "1.16.0",
-        "@oxlint/win32-arm64": "1.16.0",
-        "@oxlint/win32-x64": "1.16.0"
+        "@oxlint/darwin-arm64": "1.17.0",
+        "@oxlint/darwin-x64": "1.17.0",
+        "@oxlint/linux-arm64-gnu": "1.17.0",
+        "@oxlint/linux-arm64-musl": "1.17.0",
+        "@oxlint/linux-x64-gnu": "1.17.0",
+        "@oxlint/linux-x64-musl": "1.17.0",
+        "@oxlint/win32-arm64": "1.17.0",
+        "@oxlint/win32-x64": "1.17.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.2.0"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.16.0",
+    "oxlint": "^1.17.0",
     "taze": "^19.7.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",
     "eslint": "^9.36.0",
     "eslint-plugin-vue": "^10.5.0",
-    "oxlint": "^1.16.0",
+    "oxlint": "^1.17.0",
     "typescript-eslint": "^8.44.1"
   }
 }


### PR DESCRIPTION
## 📦 Dependencies Update

This PR updates `oxlint` from version `1.16.0` to `1.17.0` and migrates corresponding ESLint rules to oxlint.

## 🔄 Rule Migrations

The following rules have been migrated from ESLint to oxlint to avoid conflicts and ensure optimal performance:

### ESLint Core Rules
- `no-misleading-character-class`: Moved from `base.js` to oxlint config

### Vue Rules  
- `vue/no-required-prop-with-default`: Moved from `vue.js` to oxlint config
- `vue/require-typed-ref`: Moved from `vue.js` to oxlint config

## 📈 Changes Summary

- 📦 **oxlint**: `1.16.0` → `1.17.0`
- 🔧 **Node.js requirement**: Updated to `^20.19.0 || >=22.12.0`
- ✨ **New oxlint rules**: 3 rules migrated for better performance
- 🔧 **Config optimization**: Disabled migrated rules in original configs

## 🧪 Testing

All existing linting configurations remain functional. The migration ensures that:
- No breaking changes for end users
- Improved linting performance through oxlint
- Consistent rule behavior across configurations