### PR TITLE
chore: update oxlint to v1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "14.5.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.17.0",
+        "oxlint": "^1.18.0",
         "taze": "^19.7.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
         "eslint": "^9.36.0",
         "eslint-plugin-vue": "^10.5.0",
-        "oxlint": "^1.17.0",
+        "oxlint": "^1.18.0",
         "typescript-eslint": "^8.44.1"
       }
     },
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.17.0.tgz",
-      "integrity": "sha512-mVYPFmwUfV0ZNFSKlQtAniKxY9yuTa2p9JrtEwMh5B+vyoRuhjsCl0Z1uEhry+Se5pbh4WHxNP2sJVhuta6P4w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-z/4/ClV0sZYDNk/xsOZHr5BHFbAXI7LU+i3P8d/L2ejy7zF8e4WA8szd70OqVm7Gcsa81TSeeQygViR63WCQ1A==",
       "cpu": [
         "arm64"
       ],
@@ -292,9 +292,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.17.0.tgz",
-      "integrity": "sha512-5+oE0tT0IFdHdosLnOibbTBpVhjTaPfdveWc988ooZ4ap8YdAeB6heizhtm1dNa3RZ5rKucZ4SIlNYsh0f9MLw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-cQP5UtmfxZKLVyISh/BeaaK5z70AGOtQkf1wm7ZaEb0eT81PkLUdzkPwTjwyQq/TeT09uw2paVy3l2SEAO+JQA==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +306,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.17.0.tgz",
-      "integrity": "sha512-ljewxrwJzz62sHXLwgJagCtgkPnJ5oAteOaZoZ306QmANkNubkRGx9d1a/SEvl0D6obffVH23pZxETt6oyPQvQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.18.0.tgz",
+      "integrity": "sha512-JsobGeuKwpQFKSgK398QHfZ4kN9XXWJ0xvI8kofoefO/LLmj1ox3+Yln3kx425AaooruRMqBhh1JFXqEKeDxOw==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +320,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.17.0.tgz",
-      "integrity": "sha512-U1h/0lSXAGdXpMLaJsTF0+CdxcHgd2Rh2Ky8jyOVQ/pCtZahlWeQeUUkZ3CA7ANKpwymlh/iBmJzu1KZl1c2cQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.18.0.tgz",
+      "integrity": "sha512-Sds76cCqGylhywWrJcJ++4JQ45MxQKDDm7iW6Gx6C9nH+DyCPnYOjZAMYDkQiiZ3MlWCIW87SggsHkMaGO45ew==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +334,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.17.0.tgz",
-      "integrity": "sha512-38qpK/lfKHYskF5kzebe1I/aBKuAMbI+sCoUYajJIRlQkmHJ3VEXCUGhQj6qtprRVV/ECLlr6Eoo8fHy4jzdYA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.18.0.tgz",
+      "integrity": "sha512-pvBDpuf7SE3iMfwgmI3m8gandsdjs8CpIgiv/tiUhxCsKeK7gRVpiIr1XcewFrYwLn/km/EhjjFr/Kb7/CsHOA==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +348,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.17.0.tgz",
-      "integrity": "sha512-pcQ27T+xK49d8SWa52N37y7BxyDG098QEDonkoJDMQ7YOqDegQ25Vrz56VSUhgtkrO25d8B7P2raH/J1PRsW5A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.18.0.tgz",
+      "integrity": "sha512-9G0km2Rt4MAoGOVndD/7+U947dnxQkWtLX9en5Gkh3lC7HBDvVpYLopXddguWE+qbqEQKp67PiuITeyYQ4uESA==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +362,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.17.0.tgz",
-      "integrity": "sha512-WEWf89vKYUYc8ODhyh6BFsvbTzzXZ0cCFMwy4l3mMHkLn5nS9wj7+4NrBB6OJ7tlPZbi57039F9UNpH7PvVEbw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-Px9436ey0xIuU3/PuXw8EwxJSWPIxiZ9pi7FiryOMisY0dNHQP9XlGvk1MNqzyFctNmas93ZG5zyyctzLTtiUg==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +376,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.17.0.tgz",
-      "integrity": "sha512-V6TxSg7JTRqzFrAGymatY3rhIFfH0kyNcTQKe5Od6BhReCBqf6WfGQ0TCGstz9XpGdmmg3lo3zD6/M7ud9aqOA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.18.0.tgz",
+      "integrity": "sha512-6yG6xADwy3SJsBuV2TZXfDMWDAzDBpTx3Ja/shdHbhP+YiVT87rRESjT5dKmASqrzQViycgnZ71UXiTf/nxqTA==",
       "cpu": [
         "x64"
       ],
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.17.0.tgz",
-      "integrity": "sha512-pfafE/o4DDP0E9+AieMebdvgUTCGX5B3hxOqOUXjNapI5Q8DgBGIYHyYIEuwjkgwmMQpGJIaKLENE8/gwcZTKw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.18.0.tgz",
+      "integrity": "sha512-bR/XSaWwrRyt87IGdJtCIf3KLspkY4Ni7FfkOdERWihfyazs40NUMCyYICZo5ojU/8zIq+EWpa/gEf7wsoBOug==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1671,14 +1671,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.17.0",
-        "@oxlint/darwin-x64": "1.17.0",
-        "@oxlint/linux-arm64-gnu": "1.17.0",
-        "@oxlint/linux-arm64-musl": "1.17.0",
-        "@oxlint/linux-x64-gnu": "1.17.0",
-        "@oxlint/linux-x64-musl": "1.17.0",
-        "@oxlint/win32-arm64": "1.17.0",
-        "@oxlint/win32-x64": "1.17.0"
+        "@oxlint/darwin-arm64": "1.18.0",
+        "@oxlint/darwin-x64": "1.18.0",
+        "@oxlint/linux-arm64-gnu": "1.18.0",
+        "@oxlint/linux-arm64-musl": "1.18.0",
+        "@oxlint/linux-x64-gnu": "1.18.0",
+        "@oxlint/linux-x64-musl": "1.18.0",
+        "@oxlint/win32-arm64": "1.18.0",
+        "@oxlint/win32-x64": "1.18.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.2.0"
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/pnpm-workspace-yaml": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.1.1.tgz",
-      "integrity": "sha512-nGBB7h3Ped3g9dBrR6d3YNwXCKYsEg8K9J3GMmSrwGEXq3RHeGW44/B4MZW51p4FRMnyxJzTY5feSBbUjRhIHQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.1.2.tgz",
+      "integrity": "sha512-XgS7j21a+I0dSmUzDUtKp4TAqPfLwJ0kAg0uQ2dveJxFrY14/9ukaD+Mt+4jt67RH4wgRsvNsjNdKbb/7NrMwQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.17.0",
+    "oxlint": "^1.18.0",
     "taze": "^19.7.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",
     "eslint": "^9.36.0",
     "eslint-plugin-vue": "^10.5.0",
-    "oxlint": "^1.17.0",
+    "oxlint": "^1.18.0",
     "typescript-eslint": "^8.44.1"
   }
 }


### PR DESCRIPTION
## 📦 Dependencies Update

This pull request updates the oxlint dependency to the latest version.

### Changes
- 📦 oxlint: ^1.17.0 -> ^1.18.0

### Impact
- Updated both `devDependencies` and `peerDependencies` sections
- No breaking changes expected as this is a minor version update