### PR TITLE
feat: upgrade oxlint to 1.19.0 and reorganize rules

### DIFF
--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -76,6 +76,7 @@
     "eslint/no-unsafe-finally": "error",
     "eslint/no-unsafe-negation": "error",
     "eslint/no-unsafe-optional-chaining": "error",
+    "eslint/no-unused-expressions": "error",
     "eslint/no-unused-labels": "error",
     "eslint/no-unused-private-class-members": "error",
     "eslint/no-unused-vars": "error",
@@ -208,7 +209,6 @@
     "eslint/no-restricted-globals": "error",
     "eslint/no-restricted-imports": "error",
     "eslint/no-undefined": "off", // undefined should be handled in TypeScript
-    "eslint/no-unused-expressions": "error",
     "eslint/no-var": "error",
 
     "eslint/no-void": ["error", {
@@ -275,6 +275,7 @@
     "unicorn/prefer-modern-math-apis": "error",
     "unicorn/prefer-node-protocol": "error",
     "unicorn/prefer-number-properties": "error",
+    "vue/max-props": "off", // It's okay to have many props in components
 
     // Vue
     "vue/no-multiple-slot-args": "error",
@@ -313,6 +314,7 @@
     // Promise
 
     "promise/always-return": "error",
+    "promise/no-multiple-resolved": "error",
     "promise/no-promise-in-callback": "error",
 
     // TypeScript
@@ -326,6 +328,7 @@
     "unicorn/consistent-function-scoping": "error",
     "unicorn/no-accessor-recursion": "error",
     "unicorn/no-array-reverse": "error",
+    "unicorn/no-array-sort": "error",
     "unicorn/no-instanceof-builtins": "error",
     "unicorn/prefer-add-event-listener": "error",
     "unicorn/require-post-message-target-origin": "error",
@@ -403,6 +406,7 @@
     "unicorn/escape-case": "error",
     "unicorn/explicit-length-check": "error",
     "unicorn/new-for-builtins": "error",
+    "unicorn/no-array-callback-reference": "error",
     "unicorn/no-hex-escape": "error",
     "unicorn/no-instanceof-array": "error",
     "unicorn/no-lonely-if": "error",
@@ -520,6 +524,7 @@
     "import/no-duplicates": "error",
     "import/no-mutable-exports": "error",
     "import/no-named-default": "error",
+    "import/no-named-export": "off", // named exports are often useful
     "import/no-namespace": "error",
     "import/prefer-default-export": "off", // no-default-export is already enabled
 

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -22,6 +22,7 @@ export default defineConfig(
       // Disabled in favor of oxlint rules
       'vue/define-emits-declaration': 'off',
       'vue/define-props-declaration': 'off',
+      'vue/max-props': 'off',
       'vue/no-multiple-slot-args': 'off',
       'vue/no-required-prop-with-default': 'off',
       'vue/require-typed-ref': 'off',
@@ -233,7 +234,6 @@ export default defineConfig(
         skipBlankLines: true
       }],
 
-      'vue/max-props': 'off',
       'vue/max-template-depth': 'off',
       'vue/new-line-between-multi-line-property': 'error',
       'vue/next-tick-style': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "14.6.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.18.0",
+        "oxlint": "^1.19.0",
         "taze": "^19.7.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
         "eslint": "^9.36.0",
         "eslint-plugin-vue": "^10.5.0",
-        "oxlint": "^1.18.0",
-        "typescript-eslint": "^8.44.1"
+        "oxlint": "^1.19.0",
+        "typescript-eslint": "^8.45.0"
       }
     },
     "node_modules/@antfu/ni": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-26.0.1.tgz",
-      "integrity": "sha512-yGtjrmEVziDXW/7ggkzDtJkiJ8e8a9j+CtYBhT6gnvVoIXHtTc+iL+ZDMfUDe1wxRvYJrLpmHLJb5HjA5Hskyg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-26.1.0.tgz",
+      "integrity": "sha512-QlkuYC2bkrT1xjnA66/mH68hrazYlxJoESws2wQRWsAbCtIDFeZ9O6Ji5sGmYjVVtbiDRwoX5hyfS3igW6IuXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansis": "^4.1.0",
+        "ansis": "^4.2.0",
         "fzf": "^0.5.2",
         "package-manager-detector": "^1.3.0",
         "tinyexec": "^1.0.1",
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.18.0.tgz",
-      "integrity": "sha512-z/4/ClV0sZYDNk/xsOZHr5BHFbAXI7LU+i3P8d/L2ejy7zF8e4WA8szd70OqVm7Gcsa81TSeeQygViR63WCQ1A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.19.0.tgz",
+      "integrity": "sha512-dSozp6FXowhFEjmT0FC/iBWj9KziWfixxaYT367kOXZUyA0hvOzsLsBB780Swr40zvqklUR0d3fbZbziGHRJoQ==",
       "cpu": [
         "arm64"
       ],
@@ -292,9 +292,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.18.0.tgz",
-      "integrity": "sha512-cQP5UtmfxZKLVyISh/BeaaK5z70AGOtQkf1wm7ZaEb0eT81PkLUdzkPwTjwyQq/TeT09uw2paVy3l2SEAO+JQA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.19.0.tgz",
+      "integrity": "sha512-3OY1km70zTlH6b8K8AHSuaEaa4sntmAcBugMZBaJmHkioia7zxlAQV9xtQ2wsBSDQbBmcf1j5Y0NcHP7fmIZvA==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +306,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.18.0.tgz",
-      "integrity": "sha512-JsobGeuKwpQFKSgK398QHfZ4kN9XXWJ0xvI8kofoefO/LLmj1ox3+Yln3kx425AaooruRMqBhh1JFXqEKeDxOw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.19.0.tgz",
+      "integrity": "sha512-TS9wmx9B/v1f/bNXu3lIEcdNIyS0m0H0+95YIWSTGG3q2cK3FVlyUiiAieZRUzXTN89n6JXtua6dK/TVCqbmkQ==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +320,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.18.0.tgz",
-      "integrity": "sha512-Sds76cCqGylhywWrJcJ++4JQ45MxQKDDm7iW6Gx6C9nH+DyCPnYOjZAMYDkQiiZ3MlWCIW87SggsHkMaGO45ew==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.19.0.tgz",
+      "integrity": "sha512-o5RAxQfVEu7LsBUwSjEDNdM8sla8WlLMRULsTP3vgxyy1eLJxo2u+4McKtM9/P2KiZQw3NylDoaxU4Z4j/XeRQ==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +334,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.18.0.tgz",
-      "integrity": "sha512-pvBDpuf7SE3iMfwgmI3m8gandsdjs8CpIgiv/tiUhxCsKeK7gRVpiIr1XcewFrYwLn/km/EhjjFr/Kb7/CsHOA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.19.0.tgz",
+      "integrity": "sha512-QDgAP4TxXsupFEsEGYnaAaKXQQD1lJSi5Htl/b0Vl2xPz8BVBRH+bNDwVGEHVTxT7jdnO2gTEOmfEzOkRJprUQ==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +348,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.18.0.tgz",
-      "integrity": "sha512-9G0km2Rt4MAoGOVndD/7+U947dnxQkWtLX9en5Gkh3lC7HBDvVpYLopXddguWE+qbqEQKp67PiuITeyYQ4uESA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.19.0.tgz",
+      "integrity": "sha512-iOQooyYzy7RR2yHNM8oHd2Zw6CdU7/G2Uf5ryFi/cF5NV5zlSH//QSkWwrk/kLF69wKqwE8S8snV7WnRA/tXjA==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +362,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.18.0.tgz",
-      "integrity": "sha512-Px9436ey0xIuU3/PuXw8EwxJSWPIxiZ9pi7FiryOMisY0dNHQP9XlGvk1MNqzyFctNmas93ZG5zyyctzLTtiUg==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.19.0.tgz",
+      "integrity": "sha512-bvgA2fGpdBF/DpB5hZYQzx5fFFiiHxIiPF5zp24czvsIRkezVi9ZH04lCIVkMBxgvKhnU2jLXAn6E1Mbo4QrFw==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +376,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.18.0.tgz",
-      "integrity": "sha512-6yG6xADwy3SJsBuV2TZXfDMWDAzDBpTx3Ja/shdHbhP+YiVT87rRESjT5dKmASqrzQViycgnZ71UXiTf/nxqTA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.19.0.tgz",
+      "integrity": "sha512-PloVn/e1kfMsiH0urM4XIhiY0TdqDjwJlzeX8pIKDmxUsKHsjcU8fmddsZSt7K16C2nR3SQVoso2AIR00mRieA==",
       "cpu": [
         "x64"
       ],
@@ -438,17 +438,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
-      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
+      "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/type-utils": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/type-utils": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -462,7 +462,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.44.1",
+        "@typescript-eslint/parser": "^8.45.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -478,16 +478,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
-      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
+      "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -503,14 +503,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
-      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
+      "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.1",
-        "@typescript-eslint/types": "^8.44.1",
+        "@typescript-eslint/tsconfig-utils": "^8.45.0",
+        "@typescript-eslint/types": "^8.45.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -525,14 +525,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
-      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
+      "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1"
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
-      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
+      "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -560,15 +560,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
-      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
+      "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
-      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
+      "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -599,16 +599,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
-      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
+      "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.44.1",
-        "@typescript-eslint/tsconfig-utils": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
+        "@typescript-eslint/project-service": "8.45.0",
+        "@typescript-eslint/tsconfig-utils": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -654,16 +654,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
-      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
+      "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1"
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -678,13 +678,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
-      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
+      "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/types": "8.45.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.1.0.tgz",
-      "integrity": "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1421,9 +1421,9 @@
       "peer": true
     },
     "node_modules/jiti": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
-      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.18.0.tgz",
-      "integrity": "sha512-bR/XSaWwrRyt87IGdJtCIf3KLspkY4Ni7FfkOdERWihfyazs40NUMCyYICZo5ojU/8zIq+EWpa/gEf7wsoBOug==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.19.0.tgz",
+      "integrity": "sha512-MGeclRJFKaROXcPKMHOuJpOhbC4qkbLeZqSlelQioV/5YeBk/qVYZafUUpVO/yQ28Pld3srsTQusFtPNkVuvNA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1671,14 +1671,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.18.0",
-        "@oxlint/darwin-x64": "1.18.0",
-        "@oxlint/linux-arm64-gnu": "1.18.0",
-        "@oxlint/linux-arm64-musl": "1.18.0",
-        "@oxlint/linux-x64-gnu": "1.18.0",
-        "@oxlint/linux-x64-musl": "1.18.0",
-        "@oxlint/win32-arm64": "1.18.0",
-        "@oxlint/win32-x64": "1.18.0"
+        "@oxlint/darwin-arm64": "1.19.0",
+        "@oxlint/darwin-x64": "1.19.0",
+        "@oxlint/linux-arm64-gnu": "1.19.0",
+        "@oxlint/linux-arm64-musl": "1.19.0",
+        "@oxlint/linux-x64-gnu": "1.19.0",
+        "@oxlint/linux-x64-musl": "1.19.0",
+        "@oxlint/win32-arm64": "1.19.0",
+        "@oxlint/win32-x64": "1.19.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.2.0"
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/pnpm-workspace-yaml": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.1.2.tgz",
-      "integrity": "sha512-XgS7j21a+I0dSmUzDUtKp4TAqPfLwJ0kAg0uQ2dveJxFrY14/9ukaD+Mt+4jt67RH4wgRsvNsjNdKbb/7NrMwQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pnpm-workspace-yaml/-/pnpm-workspace-yaml-1.2.0.tgz",
+      "integrity": "sha512-4CnZHmLSaprRnIm2iQ27Zl1cWPRHdX7Ehw7ckRwujoPKCk2QAz4agsA2MbTodg4sgbqYfJ68ULT+Q5A8dU+Mow==",
       "dev": true,
       "funding": [
         {
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -2113,16 +2113,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
-      "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.45.0.tgz",
+      "integrity": "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.44.1",
-        "@typescript-eslint/parser": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1"
+        "@typescript-eslint/eslint-plugin": "8.45.0",
+        "@typescript-eslint/parser": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.18.0",
+    "oxlint": "^1.19.0",
     "taze": "^19.7.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",
     "eslint": "^9.36.0",
     "eslint-plugin-vue": "^10.5.0",
-    "oxlint": "^1.18.0",
-    "typescript-eslint": "^8.44.1"
+    "oxlint": "^1.19.0",
+    "typescript-eslint": "^8.45.0"
   }
 }


### PR DESCRIPTION
- 🔄 Upgraded `oxlint` from 1.18.0 to 1.19.0
- 📦 @antfu/ni: 26.0.1 -> 26.1.0
- 📦 ansis: 4.1.0 -> 4.2.0
- 📦 jiti: 2.6.0 -> 2.6.1
- 📦 pnpm-workspace-yaml: 1.1.2 -> 1.2.0
- 📦 typescript: 5.9.2 -> 5.9.3
- 📦 typescript-eslint: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/eslint-plugin: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/parser: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/project-service: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/scope-manager: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/tsconfig-utils: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/type-utils: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/types: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/typescript-estree: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/utils: 8.44.1 -> 8.45.0
- 📦 @typescript-eslint/visitor-keys: 8.44.1 -> 8.45.0
- 📦 All `@oxlint/*` platform-specific packages updated to 1.19.0
- ✨ Added `eslint/no-unused-expressions` rule to oxlint correctness section
- 🔧 Moved `eslint/no-unused-expressions` from best practices section (was redundant)
- ✨ Added `promise/no-multiple-resolved` rule to oxlint promise section
- ✨ Added `unicorn/no-array-sort` rule to oxlint correctness section
- ✨ Added `unicorn/no-array-callback-reference` rule to oxlint style section
- ✨ Added `vue/max-props` rule set to `off` in oxlint pedantic section with comment
- ✨ Added `import/no-named-export` rule set to `off` in oxlint style section with comment
- 🔄 Moved `vue/max-props` rule in `configs/vue.js` to disabled oxlint rules section
- 🗑️ Removed duplicate `vue/max-props` entry from `configs/vue.js` best practices section