### PR TITLE
chore(deps): upgrade dependencies and reorganize linting rules

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -107,6 +107,7 @@ export default defineConfig(
       'no-obj-calls': 'off',
       'no-object-constructor': 'off',
       'no-octal': 'off', // Superseded by strict mode
+      'no-param-reassign': 'error',
       'no-plusplus': 'off',
       'no-proto': 'off',
       'no-prototype-builtins': 'off',
@@ -219,7 +220,6 @@ export default defineConfig(
       'no-invalid-this': 'error',
       'no-loop-func': 'error',
       'no-octal-escape': 'error',
-      'no-param-reassign': 'error',
 
       'no-restricted-exports': ['error', {
         restrictDefaultExports: {

--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -165,6 +165,8 @@
 
     // Vue
 
+    "vue/no-export-in-script-setup": "error",
+    "vue/prefer-import-from-vue": "error",
     "vue/valid-define-emits": "error",
     "vue/valid-define-props": "error",
 
@@ -203,6 +205,7 @@
     "eslint/no-empty-function": "error",
     "eslint/no-eq-null": "error",
     "eslint/no-iterator": "error",
+    "eslint/no-param-reassign": "error",
     "eslint/no-plusplus": "error",
     "eslint/no-proto": "error",
     "eslint/no-regex-spaces": "error",
@@ -272,6 +275,7 @@
     "unicorn/no-length-as-slice-end": "error",
     "unicorn/no-magic-array-flat-depth": "error",
     "unicorn/no-process-exit": "error",
+    "unicorn/no-useless-error-capture-stack-trace": "error",
     "unicorn/prefer-modern-math-apis": "error",
     "unicorn/prefer-node-protocol": "error",
     "unicorn/prefer-number-properties": "error",
@@ -331,6 +335,7 @@
     "unicorn/no-array-sort": "error",
     "unicorn/no-instanceof-builtins": "error",
     "unicorn/prefer-add-event-listener": "error",
+    "unicorn/require-module-specifiers": "error",
     "unicorn/require-post-message-target-origin": "error",
 
     // Vue
@@ -417,6 +422,7 @@
     "unicorn/no-this-assignment": "error",
     "unicorn/no-typeof-undefined": "error",
     "unicorn/no-unnecessary-array-flat-depth": "error",
+    "unicorn/no-unnecessary-array-splice-count": "error",
     "unicorn/no-unnecessary-slice-end": "error",
     "unicorn/no-unreadable-iife": "error",
     "unicorn/no-useless-promise-resolve-reject": "error",
@@ -424,6 +430,7 @@
     "unicorn/no-useless-undefined": "error",
     "unicorn/prefer-array-flat": "error",
     "unicorn/prefer-array-some": "error",
+    "unicorn/prefer-at": "error",
     "unicorn/prefer-blob-reading-methods": "error",
     "unicorn/prefer-code-point": "error",
     "unicorn/prefer-date-now": "error",
@@ -439,6 +446,7 @@
     "unicorn/prefer-regexp-test": "error",
     "unicorn/prefer-string-replace-all": "error",
     "unicorn/prefer-string-slice": "error",
+    "unicorn/prefer-top-level-await": "error",
     "unicorn/prefer-type-error": "error",
     "unicorn/require-number-to-fixed-digits-argument": "error",
 
@@ -571,6 +579,8 @@
     "unicorn/number-literal-case": "error",
     "unicorn/numeric-separators-style": "error",
     "unicorn/prefer-array-index-of": "error",
+    "unicorn/prefer-class-fields": "error",
+    "unicorn/prefer-classlist-toggle": "error",
     "unicorn/prefer-dom-node-text-content": "error",
     "unicorn/prefer-global-this": "error",
     "unicorn/prefer-includes": "error",
@@ -599,6 +609,7 @@
     // Vue
     "vue/define-emits-declaration": "error",
     "vue/define-props-declaration": "error",
+    "vue/define-props-destructuring": "error",
     "vue/require-typed-ref": "error",
 
     /**

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -20,11 +20,15 @@ export default defineConfig(
 
     rules: {
       // Disabled in favor of oxlint rules
+
       'vue/define-emits-declaration': 'off',
       'vue/define-props-declaration': 'off',
+      'vue/define-props-destructuring': 'off',
       'vue/max-props': 'off',
+      'vue/no-export-in-script-setup': 'off',
       'vue/no-multiple-slot-args': 'off',
       'vue/no-required-prop-with-default': 'off',
+      'vue/prefer-import-from-vue': 'off',
       'vue/require-typed-ref': 'off',
       'vue/valid-define-emits': 'off',
       'vue/valid-define-props': 'off',
@@ -51,7 +55,6 @@ export default defineConfig(
       'vue/no-dupe-keys': 'error',
       'vue/no-dupe-v-else-if': 'error',
       'vue/no-duplicate-attributes': 'error',
-      'vue/no-export-in-script-setup': 'error',
       'vue/no-mutating-props': 'error',
       'vue/no-parsing-error': 'error',
       'vue/no-ref-as-operand': 'error',
@@ -119,7 +122,6 @@ export default defineConfig(
       'vue/no-lifecycle-after-await': 'error',
       'vue/no-v-for-template-key-on-child': 'error',
       'vue/no-watch-after-await': 'error',
-      'vue/prefer-import-from-vue': 'error',
       'vue/require-slots-as-functions': 'error',
       'vue/require-toggle-inside-transition': 'error',
       'vue/valid-v-is': 'error',
@@ -213,8 +215,6 @@ export default defineConfig(
       'vue/define-macros-order': ['error', {
         defineExposeLast: true
       }],
-
-      'vue/define-props-destructuring': 'error',
 
       'vue/enforce-style-attribute': ['error', {
         allow: ['module', 'plain']

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "14.7.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.19.0",
+        "oxlint": "^1.20.0",
         "taze": "^19.7.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
-        "eslint": "^9.36.0",
+        "eslint": "^9.37.0",
         "eslint-plugin-vue": "^10.5.0",
-        "oxlint": "^1.19.0",
-        "typescript-eslint": "^8.45.0"
+        "oxlint": "^1.20.0",
+        "typescript-eslint": "^8.46.0"
       }
     },
     "node_modules/@antfu/ni": {
@@ -104,19 +104,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
+      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
       "license": "Apache-2.0",
       "peer": true,
+      "dependencies": {
+        "@eslint/core": "^0.16.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -151,9 +154,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
-      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
+      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -174,13 +177,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.16.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -278,9 +281,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.19.0.tgz",
-      "integrity": "sha512-dSozp6FXowhFEjmT0FC/iBWj9KziWfixxaYT367kOXZUyA0hvOzsLsBB780Swr40zvqklUR0d3fbZbziGHRJoQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.20.0.tgz",
+      "integrity": "sha512-v6jX+9q+UCi6eR/QAimnrJ0LHxO8RolNl5vnCjmj9NKq8UqSG5v0h0CKlFrJEO8Ku30fNDTy8UEb8WSY39GM2A==",
       "cpu": [
         "arm64"
       ],
@@ -292,9 +295,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.19.0.tgz",
-      "integrity": "sha512-3OY1km70zTlH6b8K8AHSuaEaa4sntmAcBugMZBaJmHkioia7zxlAQV9xtQ2wsBSDQbBmcf1j5Y0NcHP7fmIZvA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.20.0.tgz",
+      "integrity": "sha512-Ur6MHxQukGBIwdeJgP7LOL389o2p/5TKCKcvxUT0/2KCIi2OiY6Jzx3T1efiLYTyCGG1mNo4W71NW6yhSY4GPA==",
       "cpu": [
         "x64"
       ],
@@ -306,9 +309,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.19.0.tgz",
-      "integrity": "sha512-TS9wmx9B/v1f/bNXu3lIEcdNIyS0m0H0+95YIWSTGG3q2cK3FVlyUiiAieZRUzXTN89n6JXtua6dK/TVCqbmkQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.20.0.tgz",
+      "integrity": "sha512-wxYWHYYag9mAuPurGIKiiEzZZVCypZUvt8oRgW0/SIsKFsJpOQMxaDw8mOy6X9QwIlxe3/2U+9rU892kNSVwcw==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +323,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.19.0.tgz",
-      "integrity": "sha512-o5RAxQfVEu7LsBUwSjEDNdM8sla8WlLMRULsTP3vgxyy1eLJxo2u+4McKtM9/P2KiZQw3NylDoaxU4Z4j/XeRQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.20.0.tgz",
+      "integrity": "sha512-b08v8+C/UrR/veiqVzCEIq1GNVEglYsrwpg5b//FKwdtlb16LGCTVGNPenYrbxN1DgWy6/nDomuKz4zytE/r0Q==",
       "cpu": [
         "arm64"
       ],
@@ -334,9 +337,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.19.0.tgz",
-      "integrity": "sha512-QDgAP4TxXsupFEsEGYnaAaKXQQD1lJSi5Htl/b0Vl2xPz8BVBRH+bNDwVGEHVTxT7jdnO2gTEOmfEzOkRJprUQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.20.0.tgz",
+      "integrity": "sha512-YsA4iHYiqG4yzE35uGnopVAfwAS8wRGypRzyJ+X7JjoRsu2GtJ/m6CD9eLRPqZnQcr12o9KW+hv2cXYWYvX3zg==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +351,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.19.0.tgz",
-      "integrity": "sha512-iOQooyYzy7RR2yHNM8oHd2Zw6CdU7/G2Uf5ryFi/cF5NV5zlSH//QSkWwrk/kLF69wKqwE8S8snV7WnRA/tXjA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.20.0.tgz",
+      "integrity": "sha512-mBDOJ4qaPCVrDS4lna3cCHJU9PmkjT3OIwBipWwAKTcwK40NLtLHxxbxkK1y0jyUf9hzjs4s8EB6TvdG47o5Gg==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +365,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.19.0.tgz",
-      "integrity": "sha512-bvgA2fGpdBF/DpB5hZYQzx5fFFiiHxIiPF5zp24czvsIRkezVi9ZH04lCIVkMBxgvKhnU2jLXAn6E1Mbo4QrFw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.20.0.tgz",
+      "integrity": "sha512-0Jwj7IvRzoyDoYpeoXSyChW4yfzv4R0DRuy8+l3ddixrKfzLJtKmp92Ti47ceuTzW8gstSFkuUF+iZpADPcxcA==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +379,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.19.0.tgz",
-      "integrity": "sha512-PloVn/e1kfMsiH0urM4XIhiY0TdqDjwJlzeX8pIKDmxUsKHsjcU8fmddsZSt7K16C2nR3SQVoso2AIR00mRieA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.20.0.tgz",
+      "integrity": "sha512-cONQz9srcJEeRxLPY2bqu2SS9UXmy4V0BiKfilla1LzPJWq0wt68uwFd57+/01/d4A58ccNjphOENemgi+0M6g==",
       "cpu": [
         "x64"
       ],
@@ -438,17 +441,17 @@
       "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
-      "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.0.tgz",
+      "integrity": "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/type-utils": "8.45.0",
-        "@typescript-eslint/utils": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/type-utils": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -462,7 +465,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.45.0",
+        "@typescript-eslint/parser": "^8.46.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -478,16 +481,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
-      "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.0.tgz",
+      "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -503,14 +506,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
-      "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.0.tgz",
+      "integrity": "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.45.0",
-        "@typescript-eslint/types": "^8.45.0",
+        "@typescript-eslint/tsconfig-utils": "^8.46.0",
+        "@typescript-eslint/types": "^8.46.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -525,14 +528,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
-      "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.0.tgz",
+      "integrity": "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0"
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -543,9 +546,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
-      "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.0.tgz",
+      "integrity": "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -560,15 +563,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
-      "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.0.tgz",
+      "integrity": "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0",
-        "@typescript-eslint/utils": "8.45.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -585,9 +588,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
-      "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
+      "integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -599,16 +602,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
-      "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.0.tgz",
+      "integrity": "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.45.0",
-        "@typescript-eslint/tsconfig-utils": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
+        "@typescript-eslint/project-service": "8.46.0",
+        "@typescript-eslint/tsconfig-utils": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/visitor-keys": "8.46.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -654,16 +657,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
-      "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.0.tgz",
+      "integrity": "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0"
+        "@typescript-eslint/scope-manager": "8.46.0",
+        "@typescript-eslint/types": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -678,13 +681,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
-      "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.0.tgz",
+      "integrity": "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/types": "8.46.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -951,20 +954,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
-      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+      "version": "9.37.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
+      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
+        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.36.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint/js": "9.37.0",
+        "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1655,9 +1658,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.19.0.tgz",
-      "integrity": "sha512-MGeclRJFKaROXcPKMHOuJpOhbC4qkbLeZqSlelQioV/5YeBk/qVYZafUUpVO/yQ28Pld3srsTQusFtPNkVuvNA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.20.0.tgz",
+      "integrity": "sha512-kBatK7aubK6Df7D5+i5fmxDOU8hzG5JbJNf54E+sDErGluw8wU28hCp76JlmZY9NJZeLQlum++7+YtQj3FBZTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1671,14 +1674,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.19.0",
-        "@oxlint/darwin-x64": "1.19.0",
-        "@oxlint/linux-arm64-gnu": "1.19.0",
-        "@oxlint/linux-arm64-musl": "1.19.0",
-        "@oxlint/linux-x64-gnu": "1.19.0",
-        "@oxlint/linux-x64-musl": "1.19.0",
-        "@oxlint/win32-arm64": "1.19.0",
-        "@oxlint/win32-x64": "1.19.0"
+        "@oxlint/darwin-arm64": "1.20.0",
+        "@oxlint/darwin-x64": "1.20.0",
+        "@oxlint/linux-arm64-gnu": "1.20.0",
+        "@oxlint/linux-arm64-musl": "1.20.0",
+        "@oxlint/linux-x64-gnu": "1.20.0",
+        "@oxlint/linux-x64-musl": "1.20.0",
+        "@oxlint/win32-arm64": "1.20.0",
+        "@oxlint/win32-x64": "1.20.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.2.0"
@@ -2113,16 +2116,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.45.0.tgz",
-      "integrity": "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==",
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.0.tgz",
+      "integrity": "sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.45.0",
-        "@typescript-eslint/parser": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0",
-        "@typescript-eslint/utils": "8.45.0"
+        "@typescript-eslint/eslint-plugin": "8.46.0",
+        "@typescript-eslint/parser": "8.46.0",
+        "@typescript-eslint/typescript-estree": "8.46.0",
+        "@typescript-eslint/utils": "8.46.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.19.0",
+    "oxlint": "^1.20.0",
     "taze": "^19.7.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",
-    "eslint": "^9.36.0",
+    "eslint": "^9.37.0",
     "eslint-plugin-vue": "^10.5.0",
-    "oxlint": "^1.19.0",
-    "typescript-eslint": "^8.45.0"
+    "oxlint": "^1.20.0",
+    "typescript-eslint": "^8.46.0"
   }
 }


### PR DESCRIPTION
## 📦 Updated Dependencies

- **oxlint**: 1.19.0 → 1.20.0
- **eslint**: 9.36.0 → 9.37.0
- **typescript-eslint**: 8.45.0 → 8.46.0
- **@eslint/js**: 9.36.0 → 9.37.0
- **@eslint/config-helpers**: 0.3.1 → 0.4.0
- **@eslint/core**: 0.15.2 → 0.16.0
- **@eslint/plugin-kit**: 0.3.5 → 0.4.0

## ✅ Added oxlint Rules

### Correctness
- `vue/no-export-in-script-setup`
- `vue/prefer-import-from-vue`

### Restriction
- `eslint/no-param-reassign`
- `unicorn/no-useless-error-capture-stack-trace`

### Style
- `unicorn/require-module-specifiers`

### Nursery
- `unicorn/no-unnecessary-array-splice-count`
- `unicorn/prefer-at`
- `unicorn/prefer-top-level-await`

### Stylistic
- `vue/define-props-destructuring`
- `unicorn/prefer-class-fields`
- `unicorn/prefer-classlist-toggle`

## 🔄 Reorganized Rules

- Moved `no-param-reassign` from 'Suggestions' to oxlint-disabled rules section in `configs/base.js`
- Disabled corresponding Vue and Unicorn rules in `configs/vue.js` (replaced by oxlint)
- Improved organization of disabled oxlint rules for better readability

## 🧪 Testing

All changes have been linted and verified to work correctly with the updated dependencies.