### PR TITLE
chore: upgrade oxlint to 1.22.0 and add new rule

### DIFF
--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -632,6 +632,7 @@
 
     // Oxc
 
+    "oxc/branches-sharing-code": "error",
     "oxc/no-map-spread": "error",
 
     // Promise

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "14.9.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.21.0",
+        "oxlint": "^1.22.0",
         "taze": "^19.7.0"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
         "eslint": "^9.37.0",
         "eslint-plugin-vue": "^10.5.0",
-        "oxlint": "^1.21.0",
+        "oxlint": "^1.22.0",
         "typescript-eslint": "^8.46.0"
       }
     },
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.21.0.tgz",
-      "integrity": "sha512-cWtT89iPTnksjWT9d3ydnY8/zK2nnAtN6wLsO8IIKpGKf5EWJ41VINP5ZLV8y0WkozvUhuhhUYFAsllM5svDig==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.22.0.tgz",
+      "integrity": "sha512-vfgwTA1CowVaU3QXFBjfGjbPsHbdjAiJnWX5FBaq8uXS8tksGgl0ue14MK6fVnXncWK9j69LRnkteGTixxDAfA==",
       "cpu": [
         "arm64"
       ],
@@ -295,9 +295,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.21.0.tgz",
-      "integrity": "sha512-6ztkLyvI9VfG5n+vk0NDaY+LbuY9C5c03NnPuw61azom0nh/5JBwularmDukc3Gc8kimTbbKbfI5uI7AQq+Kqw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.22.0.tgz",
+      "integrity": "sha512-70x7Y+e0Ddb2Cf2IZsYGnXZrnB/MZgOTi/VkyXZucbnQcpi2VoaYS4Ve662DaNkzvTxdKOGmyJVMmD/digdJLQ==",
       "cpu": [
         "x64"
       ],
@@ -309,9 +309,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.21.0.tgz",
-      "integrity": "sha512-7KcVtQoW9iLa8+Jkhv7KvItZZ51WaabeEgMJoVeTMSEoKUtAqPRcvhWBItQPWEx4uyFiRxl9eBiN6XX18I2KPg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.22.0.tgz",
+      "integrity": "sha512-Rv94lOyEV8WEuzhjJSpCW3DbL/tlOVizPxth1v5XAFuQdM5rgpOMs3TsAf/YFUn52/qenwVglyvQZL8oAUYlpg==",
       "cpu": [
         "arm64"
       ],
@@ -323,9 +323,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.21.0.tgz",
-      "integrity": "sha512-qurnYEbF7/v2lk5bwkbs2QINwXdumExKY+JaVPC9laJmlbw1TtqSmCE1ICcdz7Vjqwcnou8bRevERQisXkU4+Q==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.22.0.tgz",
+      "integrity": "sha512-Aau6V6Osoyb3SFmRejP3rRhs1qhep4aJTdotFf1RVMVSLJkF7Ir0p+eGZSaIJyylFZuCCxHpud3hWasphmZnzw==",
       "cpu": [
         "arm64"
       ],
@@ -337,9 +337,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.21.0.tgz",
-      "integrity": "sha512-QFl6u4SADpJOmEvtjijOzX1W/Q0z8FSZZBlrGgdGkk/91Sdjp6eBWK7yXwDlFNuRmymc0Qm8UmaW6m6NUH15bg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.22.0.tgz",
+      "integrity": "sha512-6eOtv+2gHrKw/hxUkV6hJdvYhzr0Dqzb4oc7sNlWxp64jU6I19tgMwSlmtn02r34YNSn+/NpZ/ECvQrycKUUFQ==",
       "cpu": [
         "x64"
       ],
@@ -351,9 +351,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.21.0.tgz",
-      "integrity": "sha512-MODgLM+G28cpPLr2kk3eynFVVc21TYAEh14taE7hhnJGULr1jwMeT4oXLS3mczm9FtA9bpbGOfHuC2NoB1Kn5A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.22.0.tgz",
+      "integrity": "sha512-c4O7qD7TCEfPE/FFKYvakF2sQoIP0LFZB8F5AQK4K9VYlyT1oENNRCdIiMu6irvLelOzJzkUM0XrvUCL9Kkxrw==",
       "cpu": [
         "x64"
       ],
@@ -365,9 +365,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.21.0.tgz",
-      "integrity": "sha512-61QsyLcl23UP2tW8eoG7bRoYpWDnpdoYOCW6H4Izrt86EE3vIcKx9BX9UBFYKYtCPCK3/pY61CNXE7hKOxYmMg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.22.0.tgz",
+      "integrity": "sha512-6DJwF5A9VoIbSWNexLYubbuteAL23l3YN00wUL7Wt4ZfEZu2f/lWtGB9yC9BfKLXzudq8MvGkrS0szmV0bc1VQ==",
       "cpu": [
         "arm64"
       ],
@@ -379,9 +379,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.21.0.tgz",
-      "integrity": "sha512-2yMnuVlfr4cPdIE3ZsJzEFNauRXY7E7l0M0T2Ew4Xuua7GZUtK0hawKAQhlk1qAmnOsYJcQsjNYH6EQlZ79b5w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.22.0.tgz",
+      "integrity": "sha512-nf8EZnIUgIrHlP9k26iOFMZZPoJG16KqZBXu5CG5YTAtVcu4CWlee9Q/cOS/rgQNGjLF+WPw8sVA5P3iGlYGQQ==",
       "cpu": [
         "x64"
       ],
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.21.0.tgz",
-      "integrity": "sha512-FrOyuFT90VCqJTF7mo47YIlwspB1KwZVGOtM5nLdIMwDtkEkaVCw9Flr7gjSilh7dXOb5bvuSLKmFGc18pu/Xw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.22.0.tgz",
+      "integrity": "sha512-/HYT1Cfanveim9QUM6KlPKJe9y+WPnh3SxIB7z1InWnag9S0nzxLaWEUiW1P4UGzh/No3KvtNmBv2IOiwAl2/w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1674,14 +1674,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.21.0",
-        "@oxlint/darwin-x64": "1.21.0",
-        "@oxlint/linux-arm64-gnu": "1.21.0",
-        "@oxlint/linux-arm64-musl": "1.21.0",
-        "@oxlint/linux-x64-gnu": "1.21.0",
-        "@oxlint/linux-x64-musl": "1.21.0",
-        "@oxlint/win32-arm64": "1.21.0",
-        "@oxlint/win32-x64": "1.21.0"
+        "@oxlint/darwin-arm64": "1.22.0",
+        "@oxlint/darwin-x64": "1.22.0",
+        "@oxlint/linux-arm64-gnu": "1.22.0",
+        "@oxlint/linux-arm64-musl": "1.22.0",
+        "@oxlint/linux-x64-gnu": "1.22.0",
+        "@oxlint/linux-x64-musl": "1.22.0",
+        "@oxlint/win32-arm64": "1.22.0",
+        "@oxlint/win32-x64": "1.22.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.2.0"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.21.0",
+    "oxlint": "^1.22.0",
     "taze": "^19.7.0"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.4.0",
     "eslint": "^9.37.0",
     "eslint-plugin-vue": "^10.5.0",
-    "oxlint": "^1.21.0",
+    "oxlint": "^1.22.0",
     "typescript-eslint": "^8.46.0"
   }
 }


### PR DESCRIPTION
## Changes

This PR upgrades oxlint and adds a new linting rule.

### Package Updates

- 📦 `oxlint`: 1.21.0 -> 1.22.0

### Rule Changes

- ➕ Added `oxc/branches-sharing-code` rule set to `error` in oxlintrc config