### PR TITLE
refactor(typescript): remove boolean naming convention 🧹✨

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -119,16 +119,6 @@ export default defineConfig({
       modifiers: ['const'],
       format: ['strictCamelCase', 'UPPER_CASE']
     }, {
-      selector: 'variable',
-      types: ['boolean'],
-      format: ['StrictPascalCase'],
-      prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
-
-      filter: {
-        regex: '^result$',
-        match: false
-      }
-    }, {
       selector: 'typeLike',
       format: ['StrictPascalCase']
     }, {


### PR DESCRIPTION
## What's poppin', homies? 😎🔥

This PR cleans up our TypeScript linting game by ditching those strict boolean naming rules that were cramping our style 💨🍎

### Changes Made 🛠

- ♻️ Removed the strict boolean variable naming convention rule that was forcing prefixes like `is`, `should`, `has`, `can`, `did`, `will` on all boolean variables
- 🧹 Simplified the `@typescript-eslint/naming-convention` configuration by dropping the boolean-specific selector
- 🎯 Boolean variables now follow the same chill naming rules as other const variables - either `strictCamelCase` or `UPPER_CASE`

### Why tho? 🤔💭

The old rule was too restrictive and sometimes you just wanna name your boolean variables without being forced into a specific pattern, ya feel? Now we got more flexibility while still keeping things clean 👌✨

### Impact 📊

This is a breaking change for codebases that relied on the strict boolean naming enforcement. Teams will need to update their variable names if they were relying on this rule to catch naming issues 🚨

---

Keep it real, fam! 😤🙏