### PR TITLE
feat(rules): sync ESLint rules with oxlint and update dependencies

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -18,6 +18,7 @@ export default defineConfig(
        * Off in favor of oxlint
        */
 
+      'accessor-pairs': 'off',
       'array-callback-return': 'off',
       'arrow-body-style': 'off',
       'block-scoped-var': 'off',
@@ -83,6 +84,7 @@ export default defineConfig(
       'no-fallthrough': 'off',
       'no-func-assign': 'off',
       'no-global-assign': 'off',
+      'no-implicit-coercion': 'off',
       'no-import-assign': 'off',
       'no-inner-declarations': 'off',
       'no-invalid-regexp': 'off',
@@ -92,6 +94,7 @@ export default defineConfig(
       'no-labels': 'off',
       'no-lone-blocks': 'off',
       'no-lonely-if': 'off',
+      'no-loop-func': 'off',
       'no-loss-of-precision': 'off',
       'no-magic-numbers': 'off',
       'no-misleading-character-class': 'off',
@@ -110,6 +113,7 @@ export default defineConfig(
       'no-octal': 'off', // Superseded by strict mode
       'no-param-reassign': 'error',
       'no-plusplus': 'off',
+      'no-promise-executor-return': 'off',
       'no-proto': 'off',
       'no-prototype-builtins': 'off',
       'no-regex-spaces': 'off',
@@ -119,6 +123,7 @@ export default defineConfig(
       'no-script-url': 'off',
       'no-self-assign': 'off',
       'no-self-compare': 'off',
+      'no-sequences': 'off',
       'no-setter-return': 'off',
       'no-shadow-restricted-names': 'off',
       'no-sparse-arrays': 'off',
@@ -184,7 +189,6 @@ export default defineConfig(
        * {@link https://eslint.org/docs/rules/#possible-problems}
        */
 
-      'no-promise-executor-return': 'error',
       'no-unmodified-loop-condition': 'error',
       'no-unreachable-loop': 'error',
       'no-use-before-define': 'error',
@@ -198,7 +202,6 @@ export default defineConfig(
        *
        * {@link https://eslint.org/docs/rules/#suggestions}
        */
-      'accessor-pairs': 'error',
       camelcase: 'error',
 
       // Doesn't matter actually
@@ -215,12 +218,10 @@ export default defineConfig(
       'id-match': 'error',
       'logical-assignment-operators': 'error',
       'max-statements': 'off',
-      'no-implicit-coercion': 'error',
       'no-implicit-globals': 'error',
       'no-implied-eval': 'error',
       'no-inline-comments': 'error',
       'no-invalid-this': 'error',
-      'no-loop-func': 'error',
       'no-octal-escape': 'error',
 
       'no-restricted-exports': ['error', {
@@ -234,7 +235,6 @@ export default defineConfig(
 
       'no-restricted-properties': 'error',
       'no-restricted-syntax': 'error',
-      'no-sequences': 'error',
       'no-shadow': 'error',
 
       'no-underscore-dangle': ['error', {

--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -211,6 +211,7 @@
     "eslint/no-regex-spaces": "error",
     "eslint/no-restricted-globals": "error",
     "eslint/no-restricted-imports": "error",
+    "eslint/no-sequences": "error",
     "eslint/no-undefined": "off", // undefined should be handled in TypeScript
     "eslint/no-var": "error",
 
@@ -350,6 +351,7 @@
 
     // ESLint
 
+    "eslint/accessor-pairs": "error",
     "eslint/array-callback-return": "error",
     "eslint/eqeqeq": "error",
     "eslint/max-classes-per-file": "error",
@@ -370,9 +372,11 @@
     "eslint/no-fallthrough": "error",
     "eslint/no-inner-declarations": "error",
     "eslint/no-lonely-if": "error",
+    "eslint/no-loop-func": "error",
     "eslint/no-negated-condition": "error",
     "eslint/no-new-wrappers": "error",
     "eslint/no-object-constructor": "error",
+    "eslint/no-promise-executor-return": "error",
     "eslint/no-prototype-builtins": "error",
     "eslint/no-redeclare": "error",
     "eslint/no-self-compare": "error",
@@ -490,6 +494,7 @@
     "eslint/no-continue": "error",
     "eslint/no-duplicate-imports": "error",
     "eslint/no-extra-label": "error",
+    "eslint/no-implicit-coercion": "error",
     "eslint/no-label-var": "error",
     "eslint/no-labels": "error",
     "eslint/no-lone-blocks": "error",
@@ -588,9 +593,11 @@
     "unicorn/prefer-bigint-literals": "error",
     "unicorn/prefer-class-fields": "error",
     "unicorn/prefer-classlist-toggle": "error",
+    "unicorn/prefer-default-parameters": "error",
     "unicorn/prefer-dom-node-text-content": "error",
     "unicorn/prefer-global-this": "error",
     "unicorn/prefer-includes": "error",
+    "unicorn/prefer-keyboard-event-key": "error",
     "unicorn/prefer-logical-operator-over-ternary": "error",
     "unicorn/prefer-modern-dom-apis": "error",
     "unicorn/prefer-negative-index": "error",

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -237,6 +237,7 @@ export default defineConfig({
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'error',
 
+    '@typescript-eslint/no-useless-default-assignment': 'error',
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/no-array-delete': 'error',
     '@typescript-eslint/no-deprecated': 'error'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "14.15.0",
       "license": "MIT",
       "devDependencies": {
-        "oxlint": "^1.32.0",
+        "oxlint": "^1.33.0",
         "taze": "^19.9.2"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.6.1",
         "eslint": "^9.39.2",
         "eslint-plugin-vue": "^10.6.2",
-        "oxlint": "^1.32.0",
-        "typescript-eslint": "^8.49.0"
+        "oxlint": "^1.33.0",
+        "typescript-eslint": "^8.50.0"
       }
     },
     "node_modules/@antfu/ni": {
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-yrqPmZYu5Qb+49h0P5EXVIq8VxYkDDM6ZQrWzlh16+UGFcD8HOXs4oF3g9RyfaoAbShLCXooSQsM/Ifwx8E/eQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-PmEQDLHAxiAdyttQ1ZWXd+5VpHLbHf3FTMJL9bg5TZamDnhNiW/v0Pamv3MTAdymnoDI3H8IVLAN/SAseV/adw==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +244,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-pQRZrJG/2nAKc3IuocFbaFFbTDlQsjz2WfivRsMn0hw65EEsSuM84WMFMiAfLpTGyTICeUtHZLHlrM5lzVr36A==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-2R9aH3kR0X2M30z5agGikv3tfNTi8/uLhU5/tYktu33VGUXpbf0OLZSlD25UEuwOKAlf3RVtzV5oDyjoq93JuQ==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +258,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-tyomSmU2DzwcTmbaWFmStHgVfRmJDDvqcIvcw4fRB1YlL2Qg/XaM4NJ0m2bdTap38gxD5FSxSgCo0DkQ8GTolg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-yb/k8GaMDgnX2LyO6km33kKItZ/n573SlbiHBBFU2HmeU7tzEHL5jHkHQXXcysUkapmqHd7UsDhOZDqPmXaQRg==",
       "cpu": [
         "arm64"
       ],
@@ -272,9 +272,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-0W46dRMaf71OGE4+Rd+GHfS1uF/UODl5Mef6871pMhN7opPGfTI2fKJxh9VzRhXeSYXW/Z1EuCq9yCfmIJq+5Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-03pt9IO1C4ZfVOW6SQiOK26mzklAhLM3Kc79OXpX1kgZRlxk+rvFoMhlgCOzn7tEdrEgbePkBoxNnwDnJDFqJQ==",
       "cpu": [
         "arm64"
       ],
@@ -286,9 +286,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-5+6myVCBOMvM62rDB9T3CARXUvIwhGqte6E+HoKRwYaqsxGUZ4bh3pItSgSFwHjLGPrvADS11qJUkk39eQQBzQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-Z7ImLWM50FoVXzYvyxUQ+QwBkBfRyK4YdLEGonyAGMp7iT3DksonDaTK9ODnJ1qHyAyAZCvuqXD7AEDsDvzDbA==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +300,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-qwQlwYYgVIC6ScjpUwiKKNyVdUlJckrfwPVpIjC9mvglIQeIjKuuyaDxUZWIOc/rEzeCV/tW6tcbehLkfEzqsw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-idb55Uzu5kkqqpMiVUfI9nP7zOqPZinQKsIRQAIU40wILcf/ijvhNZKIu3ucDMmye0n6IWOaSnxIRL5W2fNoUQ==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +314,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.32.0.tgz",
-      "integrity": "sha512-7qYZF9CiXGtdv8Z/fBkgB5idD2Zokht67I5DKWH0fZS/2R232sDqW2JpWVkXltk0+9yFvmvJ0ouJgQRl9M3S2g==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.33.0.tgz",
+      "integrity": "sha512-wKKFt7cubfrLelNzdmDsNSmtBrlSUe1fWus587+uSxDZdpFbQ7liU0gsUlCbcHvym0H1Tc2O3K3cnLrgQORLPQ==",
       "cpu": [
         "arm64"
       ],
@@ -328,9 +328,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.32.0.tgz",
-      "integrity": "sha512-XW1xqCj34MEGJlHteqasTZ/LmBrwYIgluhNW0aP+XWkn90+stKAq3W/40dvJKbMK9F7o09LPCuMVtUW7FIUuiA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.33.0.tgz",
+      "integrity": "sha512-ReyR8rNHjKNnO7dxGny9RCPELRAdhm3y780FNBcA07E1wvxSCkB+Mn5db0Pa5bRmxrsU/MTZ/aaBFa+ERXDdXw==",
       "cpu": [
         "x64"
       ],
@@ -388,16 +388,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
-      "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
+      "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/type-utils": "8.49.0",
-        "@typescript-eslint/utils": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/type-utils": "8.50.0",
+        "@typescript-eslint/utils": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.1.0"
@@ -410,7 +410,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.49.0",
+        "@typescript-eslint/parser": "^8.50.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -425,16 +425,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
-      "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
+      "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -450,13 +450,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
-      "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
+      "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.49.0",
-        "@typescript-eslint/types": "^8.49.0",
+        "@typescript-eslint/tsconfig-utils": "^8.50.0",
+        "@typescript-eslint/types": "^8.50.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -471,13 +471,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
-      "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
+      "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0"
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
-      "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
+      "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -504,14 +504,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
-      "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
+      "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0",
-        "@typescript-eslint/utils": "8.49.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0",
+        "@typescript-eslint/utils": "8.50.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
-      "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
+      "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -541,15 +541,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
-      "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
+      "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.49.0",
-        "@typescript-eslint/tsconfig-utils": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/visitor-keys": "8.49.0",
+        "@typescript-eslint/project-service": "8.50.0",
+        "@typescript-eslint/tsconfig-utils": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/visitor-keys": "8.50.0",
         "debug": "^4.3.4",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -592,15 +592,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
-      "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
+      "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.49.0",
-        "@typescript-eslint/types": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0"
+        "@typescript-eslint/scope-manager": "8.50.0",
+        "@typescript-eslint/types": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -615,12 +615,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
-      "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
+      "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/types": "8.50.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.32.0.tgz",
-      "integrity": "sha512-HYDQCga7flsdyLMUIxTgSnEx5KBxpP9VINB8NgO+UjV80xBiTQXyVsvjtneMT3ZBLMbL0SlG/Dm03XQAsEshMA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.33.0.tgz",
+      "integrity": "sha512-4WCL0K8jiOshwJ8WrVk35VAuVaZHC0iX6asjKsrENOrynkAAGcTLLx0Urf0eXZ1Tq7r+qAe3Z9EyHMFPzVyUkg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1433,17 +1433,17 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.32.0",
-        "@oxlint/darwin-x64": "1.32.0",
-        "@oxlint/linux-arm64-gnu": "1.32.0",
-        "@oxlint/linux-arm64-musl": "1.32.0",
-        "@oxlint/linux-x64-gnu": "1.32.0",
-        "@oxlint/linux-x64-musl": "1.32.0",
-        "@oxlint/win32-arm64": "1.32.0",
-        "@oxlint/win32-x64": "1.32.0"
+        "@oxlint/darwin-arm64": "1.33.0",
+        "@oxlint/darwin-x64": "1.33.0",
+        "@oxlint/linux-arm64-gnu": "1.33.0",
+        "@oxlint/linux-arm64-musl": "1.33.0",
+        "@oxlint/linux-x64-gnu": "1.33.0",
+        "@oxlint/linux-x64-musl": "1.33.0",
+        "@oxlint/win32-arm64": "1.33.0",
+        "@oxlint/win32-x64": "1.33.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.8.1"
+        "oxlint-tsgolint": ">=0.9.0"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
@@ -1793,16 +1793,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.49.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
-      "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.0.tgz",
+      "integrity": "sha512-Q1/6yNUmCpH94fbgMUMg2/BSAr/6U7GBk61kZTv1/asghQOWOjTlp9K8mixS5NcJmm2creY+UFfGeW/+OcA64A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.49.0",
-        "@typescript-eslint/parser": "8.49.0",
-        "@typescript-eslint/typescript-estree": "8.49.0",
-        "@typescript-eslint/utils": "8.49.0"
+        "@typescript-eslint/eslint-plugin": "8.50.0",
+        "@typescript-eslint/parser": "8.50.0",
+        "@typescript-eslint/typescript-estree": "8.50.0",
+        "@typescript-eslint/utils": "8.50.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
     "oxlint"
   ],
   "devDependencies": {
-    "oxlint": "^1.32.0",
+    "oxlint": "^1.33.0",
     "taze": "^19.9.2"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.6.1",
     "eslint": "^9.39.2",
     "eslint-plugin-vue": "^10.6.2",
-    "oxlint": "^1.32.0",
-    "typescript-eslint": "^8.49.0"
+    "oxlint": "^1.33.0",
+    "typescript-eslint": "^8.50.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR synchronizes ESLint rules with oxlint and updates dependencies to their latest versions.

## Changes

### Rules Migration
Moved several ESLint rules from base config to oxlint to avoid duplication:
- `accessor-pairs` - moved from suggestions to oxlint
- `no-implicit-coercion` - moved from suggestions to oxlint
- `no-loop-func` - moved from suggestions to oxlint
- `no-promise-executor-return` - moved from problems to oxlint
- `no-sequences` - moved from suggestions to oxlint

### New oxlint Rules
Added new rules to oxlint configuration:
- `eslint/accessor-pairs` - added to style rules
- `eslint/no-implicit-coercion` - added to style rules
- `eslint/no-loop-func` - added to style rules
- `eslint/no-promise-executor-return` - added to style rules
- `eslint/no-sequences` - added to restriction rules
- `unicorn/prefer-default-parameters` - added to style rules
- `unicorn/prefer-keyboard-event-key` - added to style rules

### TypeScript Rules
- Added `@typescript-eslint/no-useless-default-assignment` rule

### Dependency Updates
- **oxlint**: `v1.32.0` → `v1.33.0`
- **typescript-eslint**: `v8.49.0` → `v8.50.0`

## Motivation

- Reduce rule duplication between ESLint and oxlint configurations
- Leverage oxlint's performance for additional rules
- Keep dependencies up to date with latest bug fixes and improvements