### PR TITLE
feat(vue): add new rules and bump deps

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -38,6 +38,13 @@
           "ignore": ["valibot"]
         }]
       }
+    },
+    {
+      "files": ["configs/*.js"],
+
+      "rules": {
+        "eslint/max-lines": "off"
+      }
     }
   ]
 }

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -292,13 +292,38 @@ export default defineConfig(
       'vue/no-useless-v-bind': 'error',
       'vue/no-v-text': 'error',
       'vue/padding-line-between-blocks': 'error',
-      'vue/padding-line-between-tags': 'off',
+
+      'vue/padding-line-between-tags': ['error', [
+        {
+          blankLine: 'always',
+          prev: '*:single-line',
+          next: '*:multi-line'
+        },
+        {
+          blankLine: 'always',
+          prev: '*:multi-line',
+          next: '*:single-line'
+        },
+        {
+          blankLine: 'always',
+          prev: '*:multi-line',
+          next: '*:multi-line'
+        },
+        {
+          blankLine: 'never',
+          prev: '*:single-line',
+          next: '*:single-line'
+        }
+      ]],
+
       'vue/padding-lines-in-component-definition': 'error',
       'vue/prefer-define-options': 'error',
       'vue/prefer-prop-type-boolean-first': 'error',
       'vue/prefer-separate-static-class': 'error',
+      'vue/prefer-single-event-payload': 'error',
       'vue/prefer-true-attribute-shorthand': 'error',
       'vue/prefer-use-template-ref': 'error',
+      'vue/prefer-v-model': 'error',
       'vue/require-direct-export': 'error',
       'vue/require-emit-validator': 'error',
       'vue/require-explicit-slots': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,20 +16,20 @@
         "taze": "^19.11.0",
         "valibot": "1.3.1",
         "vitest": "^4.1.5",
-        "vue": "^3.5.32"
+        "vue": "^3.5.33"
       },
       "peerDependencies": {
         "@stylistic/eslint-plugin": "^5.10.0",
         "eslint": "^10.2.1",
-        "eslint-plugin-vue": "^10.8.0",
+        "eslint-plugin-vue": "^10.9.0",
         "oxlint": "^1.61.0",
         "typescript-eslint": "^8.59.0"
       }
     },
     "node_modules/@antfu/ni": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-30.0.0.tgz",
-      "integrity": "sha512-DqBVB3XqXH4VsDpER7iLlEtayMC98iXrY7kwBzp1v6LGc/6U6+qnN3+X0bcPK63LMXJCRG2D/XDq7dvtKDGogg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-30.1.0.tgz",
+      "integrity": "sha512-3VuAbPjgY52rQNn4wABaXMhBU2Oq91uy6L8nX49eJ35OLI68CyckGU+HZxcaHix4ymuGM2nFL1D6sLpgODK5xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,14 +1458,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@vue/shared": "3.5.33",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -1479,31 +1479,31 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
       }
     },
@@ -1515,68 +1515,68 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.32"
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
-        "vue": "3.5.32"
+        "vue": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.8.0.tgz",
-      "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.0.tgz",
+      "integrity": "sha512-EFNNzu4HqtTRb5DJINpyd+u3bDdzETWDMpCzG+UBHz1tpsnMDCeOcf61u4Wy/cbXnMymK+MT9bjH7KcG1fItSw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3674,17 +3674,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "taze": "^19.11.0",
     "valibot": "1.3.1",
     "vitest": "^4.1.5",
-    "vue": "^3.5.32"
+    "vue": "^3.5.33"
   },
   "peerDependencies": {
     "@stylistic/eslint-plugin": "^5.10.0",
     "eslint": "^10.2.1",
-    "eslint-plugin-vue": "^10.8.0",
+    "eslint-plugin-vue": "^10.9.0",
     "oxlint": "^1.61.0",
     "typescript-eslint": "^8.59.0"
   }


### PR DESCRIPTION
## What's in this PR? 😎🔥

Bumped `eslint-plugin-vue` to v10.9.0 and enabled the new Vue rules that came along for the ride🏄, plus a couple of quality-of-life tweaks🔧.

## Changes

### New Vue rules 🆕

- ✨ `vue/padding-line-between-tags` — enforces blank lines between multi-line and single-line tags (and forbids them between two single-line tags)
- ✨ `vue/prefer-single-event-payload` — disallows emitting multiple payload arguments, keep it clean💅
- ✨ `vue/prefer-v-model` — prefers `v-model` shorthand over manual prop+event bindings

### Local linting fix 🔧

- Disabled `eslint/max-lines` for `configs/*.js` in `.oxlintrc.jsonc` — those files are config catalogs and the line limit doesn't apply there

### Dependency bumps 📦

- `eslint-plugin-vue`: `^10.8.0` → `^10.9.0`
- `vue`: `^3.5.32` → `^3.5.33`
- `@antfu/ni`: `30.0.0` → `30.1.0`