### PR TITLE
Add rules from oxlint 1.68

### DIFF
--- a/.agents/skills/oxlint-changelog/SKILL.md
+++ b/.agents/skills/oxlint-changelog/SKILL.md
@@ -91,6 +91,7 @@ Inspect the relevant config files and classify the current state:
 
 This matters because the same changelog line can imply different follow-up:
 
+- **new oxlint rule in an already enabled repository plugin namespace and not configured yet** → likely `add`
 - **new oxlint implementation of a rule already enforced via ESLint** → likely `add` / `migrate`
 - **rename / replacement / deprecation** → likely `replace` or `remove`
 - **new option or behavior fix on a rule already configured** → likely `adjust` or `review-only`
@@ -120,6 +121,7 @@ Treat an entry as actionable only when there is a concrete repository change imp
 
 Good examples of actionable items:
 
+- a supported oxlint plugin gains a new rule and the repository does not configure it yet
 - a supported oxlint rule has just been implemented and the repository still enforces the equivalent ESLint rule
 - a supported rule was renamed or replaced and the repository currently uses the old name
 - a supported rule gained an option that the repository is already relying on or should now align with
@@ -185,9 +187,11 @@ If the user says "apply the obvious ones" or similar, use only the clearly actio
 
 - Do not suggest enabling an entire new plugin because one release note mentions it.
 - Do not treat changelog noise as mandatory work.
-- Do not recommend config edits for rules the repository does not use unless the changelog clearly adds a valuable supported rule and the user wants adoption work.
+- For this repository, when a changelog adds a new rule under an already enabled oxlint plugin namespace, treat it as `add` by default unless repository context shows an explicit local opt-out or conflict.
+- Do not recommend config edits for rules under unsupported plugins or for speculative plugin expansion.
 - If a rule is already handled by oxlint in the repository, a bug fix is usually `review-only`, not a config change.
 - If a rule is currently enforced only in ESLint-side config and Oxlint just gained support, that is a strong candidate for `migrate`.
+- If a rule is already enabled in oxlint, do not list it as actionable again; classify follow-up bug fixes or diagnostics changes as `review-only` unless a config adjustment is clearly needed.
 
 ## Worked examples
 

--- a/configs/base.js
+++ b/configs/base.js
@@ -177,6 +177,7 @@ export default defineConfig(
       'prefer-const': 'off',
       'prefer-destructuring': 'off',
       'prefer-exponentiation-operator': 'off',
+      'prefer-named-capture-group': 'off',
       'prefer-numeric-literals': 'off',
       'prefer-object-has-own': 'off',
       'prefer-object-spread': 'off',
@@ -224,7 +225,6 @@ export default defineConfig(
       'no-octal-escape': 'error',
       'no-restricted-syntax': 'error',
       'one-var': ['error', 'never'],
-      'prefer-named-capture-group': 'error',
       strict: 'error'
     }
   }

--- a/configs/oxlintrc.jsonc
+++ b/configs/oxlintrc.jsonc
@@ -202,10 +202,12 @@
     "vue/no-expose-after-await": "error",
     "vue/no-export-in-script-setup": "error",
     "vue/no-lifecycle-after-await": "error",
+    "vue/no-reserved-component-names": "error",
     "vue/no-shared-component-data": "error",
     "vue/no-this-in-before-route-enter": "error",
     "vue/no-watch-after-await": "error",
     "vue/prefer-import-from-vue": "error",
+    "vue/require-prop-type-constructor": "error",
     "vue/require-render-return": "error",
     "vue/require-slots-as-functions": "error",
     "vue/return-in-computed-property": "off", // It seems to be too strict and not very useful
@@ -494,6 +496,7 @@
     "jsdoc/require-returns-description": "error",
     "jsdoc/require-returns-type": "off", // TODO: probably not needed when types annotated correctly
     "jsdoc/require-throws-type": "error",
+    "jsdoc/require-yields-description": "error",
     "jsdoc/require-yields-type": "error",
 
     // Oxc
@@ -647,6 +650,7 @@
     "eslint/prefer-const": "error",
     "eslint/prefer-destructuring": "error",
     "eslint/prefer-exponentiation-operator": "error",
+    "eslint/prefer-named-capture-group": "error",
     "eslint/prefer-numeric-literals": "error",
     "eslint/prefer-object-has-own": "error",
     "eslint/prefer-object-spread": "error",
@@ -713,6 +717,7 @@
     "typescript/consistent-type-exports": "error",
     "typescript/consistent-type-imports": "error",
     "typescript/dot-notation": "error",
+    "typescript/method-signature-style": "error",
     "typescript/no-empty-interface": "error",
     "typescript/no-inferrable-types": "error",
     "typescript/no-unnecessary-qualifier": "error",
@@ -778,6 +783,7 @@
     "unicorn/throw-new-error": "error",
 
     // Vue
+    "vue/component-definition-name-casing": "error",
     "vue/define-emits-declaration": "error",
     "vue/define-props-declaration": "error",
     "vue/define-props-destructuring": "off", // It requires destructuring, even when not needed

--- a/configs/oxlintrc.vitest.jsonc
+++ b/configs/oxlintrc.vitest.jsonc
@@ -71,6 +71,7 @@
           "pattern": ".*\\.test\\.ts"
         }],
 
+        "vitest/consistent-test-it": "error",
         "vitest/consistent-vitest-vi": "error",
         "vitest/max-expects": "off",
         "vitest/max-nested-describe": "error",

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -46,6 +46,7 @@ export default defineConfig({
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/init-declarations': 'off',
     '@typescript-eslint/max-params': 'off',
+    '@typescript-eslint/method-signature-style': 'off',
     '@typescript-eslint/no-array-constructor': 'off',
     '@typescript-eslint/no-array-delete': 'off',
     '@typescript-eslint/no-base-to-string': 'off',
@@ -159,9 +160,6 @@ export default defineConfig({
         'method'
       ]
     }],
-
-    '@typescript-eslint/method-signature-style': 'error',
-
     '@typescript-eslint/naming-convention': ['error', {
       // Ignore destructured variables
       selector: 'variable',

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -21,6 +21,7 @@ export default defineConfig(
     rules: {
       // Disabled in favor of oxlint rules
 
+      'vue/component-definition-name-casing': 'off',
       'vue/define-emits-declaration': 'off',
       'vue/define-props-declaration': 'off',
       'vue/define-props-destructuring': 'off',
@@ -39,12 +40,14 @@ export default defineConfig(
       'vue/no-import-compiler-macros': 'off',
       'vue/no-lifecycle-after-await': 'off',
       'vue/no-multiple-slot-args': 'off',
+      'vue/no-reserved-component-names': 'off',
       'vue/no-required-prop-with-default': 'off',
       'vue/no-shared-component-data': 'off',
       'vue/no-this-in-before-route-enter': 'off',
       'vue/no-watch-after-await': 'off',
       'vue/prefer-import-from-vue': 'off',
       'vue/require-default-export': 'off',
+      'vue/require-prop-type-constructor': 'off',
       'vue/require-render-return': 'off',
       'vue/require-slots-as-functions': 'off',
       'vue/require-typed-ref': 'off',
@@ -77,7 +80,6 @@ export default defineConfig(
       'vue/no-mutating-props': 'error',
       'vue/no-parsing-error': 'error',
       'vue/no-ref-as-operand': 'error',
-      'vue/no-reserved-component-names': 'error',
       'vue/no-reserved-keys': 'error',
       'vue/no-reserved-props': 'error',
       'vue/no-side-effects-in-computed-properties': 'error',
@@ -93,7 +95,6 @@ export default defineConfig(
       'vue/no-useless-template-attributes': 'error',
       'vue/no-v-text-v-html-on-component': 'error',
       'vue/require-component-is': 'error',
-      'vue/require-prop-type-constructor': 'error',
       'vue/require-v-for-key': 'error',
       'vue/require-valid-default-prop': 'error',
       'vue/use-v-on-exact': 'error',
@@ -139,8 +140,6 @@ export default defineConfig(
        */
 
       'vue/attribute-hyphenation': 'error',
-      'vue/component-definition-name-casing': 'error',
-
       'vue/first-attribute-linebreak': ['error', {
         singleline: 'beside',
         multiline: 'below'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^25.9.1",
         "execa": "^9.6.1",
         "husky": "^9.1.7",
-        "oxlint": "^1.67.0",
+        "oxlint": "^1.68.0",
         "taze": "^19.14.1",
         "valibot": "1.4.1",
         "vitest": "^4.1.7",
@@ -22,7 +22,7 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "eslint": "^10.4.0",
         "eslint-plugin-vue": "^10.9.1",
-        "oxlint": "^1.67.0",
+        "oxlint": "^1.68.0",
         "oxlint-tsgolint": "^0.23.0",
         "typescript-eslint": "^8.60.0"
       }
@@ -438,9 +438,9 @@
       "peer": true
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
-      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.68.0.tgz",
+      "integrity": "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==",
       "cpu": [
         "arm"
       ],
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
-      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.68.0.tgz",
+      "integrity": "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==",
       "cpu": [
         "arm64"
       ],
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
-      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.68.0.tgz",
+      "integrity": "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==",
       "cpu": [
         "arm64"
       ],
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
-      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.68.0.tgz",
+      "integrity": "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==",
       "cpu": [
         "x64"
       ],
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
-      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.68.0.tgz",
+      "integrity": "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==",
       "cpu": [
         "x64"
       ],
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
-      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.68.0.tgz",
+      "integrity": "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==",
       "cpu": [
         "arm"
       ],
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
-      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.68.0.tgz",
+      "integrity": "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==",
       "cpu": [
         "arm"
       ],
@@ -557,9 +557,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
-      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.68.0.tgz",
+      "integrity": "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==",
       "cpu": [
         "arm64"
       ],
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
-      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.68.0.tgz",
+      "integrity": "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==",
       "cpu": [
         "arm64"
       ],
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
-      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==",
       "cpu": [
         "ppc64"
       ],
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
-      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.68.0.tgz",
+      "integrity": "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==",
       "cpu": [
         "riscv64"
       ],
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
-      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.68.0.tgz",
+      "integrity": "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==",
       "cpu": [
         "riscv64"
       ],
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
-      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.68.0.tgz",
+      "integrity": "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==",
       "cpu": [
         "s390x"
       ],
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
-      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==",
       "cpu": [
         "x64"
       ],
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
-      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.68.0.tgz",
+      "integrity": "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==",
       "cpu": [
         "x64"
       ],
@@ -717,9 +717,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
-      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.68.0.tgz",
+      "integrity": "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
-      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.68.0.tgz",
+      "integrity": "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==",
       "cpu": [
         "arm64"
       ],
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
-      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.68.0.tgz",
+      "integrity": "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==",
       "cpu": [
         "ia32"
       ],
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
-      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.68.0.tgz",
+      "integrity": "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==",
       "cpu": [
         "x64"
       ],
@@ -2945,9 +2945,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
-      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.68.0.tgz",
+      "integrity": "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2960,25 +2960,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.67.0",
-        "@oxlint/binding-android-arm64": "1.67.0",
-        "@oxlint/binding-darwin-arm64": "1.67.0",
-        "@oxlint/binding-darwin-x64": "1.67.0",
-        "@oxlint/binding-freebsd-x64": "1.67.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
-        "@oxlint/binding-linux-arm64-musl": "1.67.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-musl": "1.67.0",
-        "@oxlint/binding-openharmony-arm64": "1.67.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
-        "@oxlint/binding-win32-x64-msvc": "1.67.0"
+        "@oxlint/binding-android-arm-eabi": "1.68.0",
+        "@oxlint/binding-android-arm64": "1.68.0",
+        "@oxlint/binding-darwin-arm64": "1.68.0",
+        "@oxlint/binding-darwin-x64": "1.68.0",
+        "@oxlint/binding-freebsd-x64": "1.68.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.68.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.68.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.68.0",
+        "@oxlint/binding-linux-arm64-musl": "1.68.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.68.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-musl": "1.68.0",
+        "@oxlint/binding-openharmony-arm64": "1.68.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.68.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.68.0",
+        "@oxlint/binding-win32-x64-msvc": "1.68.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.22.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^25.9.1",
     "execa": "^9.6.1",
     "husky": "^9.1.7",
-    "oxlint": "^1.67.0",
+    "oxlint": "^1.68.0",
     "taze": "^19.14.1",
     "valibot": "1.4.1",
     "vitest": "^4.1.7",
@@ -50,7 +50,7 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "eslint": "^10.4.0",
     "eslint-plugin-vue": "^10.9.1",
-    "oxlint": "^1.67.0",
+    "oxlint": "^1.68.0",
     "oxlint-tsgolint": "^0.23.0",
     "typescript-eslint": "^8.60.0"
   }

--- a/tests/oxlint/__tests__/component-definition-name-casing.invalid.vue
+++ b/tests/oxlint/__tests__/component-definition-name-casing.invalid.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export default {
+  name: 'user-panel'
+};
+</script>

--- a/tests/oxlint/__tests__/component-definition-name-casing.test.ts
+++ b/tests/oxlint/__tests__/component-definition-name-casing.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'vue/component-definition-name-casing';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'component-definition-name-casing.valid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'component-definition-name-casing.invalid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/component-definition-name-casing.valid.vue
+++ b/tests/oxlint/__tests__/component-definition-name-casing.valid.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export default {
+  name: 'UserPanel'
+};
+</script>

--- a/tests/oxlint/__tests__/consistent-test-it.invalid.ts
+++ b/tests/oxlint/__tests__/consistent-test-it.invalid.ts
@@ -1,0 +1,6 @@
+import { describe, test } from 'vitest';
+
+describe('consistent test it', () => {
+  test('uses test keyword', () => {
+  });
+});

--- a/tests/oxlint/__tests__/method-signature-style.invalid.ts
+++ b/tests/oxlint/__tests__/method-signature-style.invalid.ts
@@ -1,0 +1,5 @@
+interface Service {
+  connect(): void;
+}
+
+void ({} as Service);

--- a/tests/oxlint/__tests__/method-signature-style.test.ts
+++ b/tests/oxlint/__tests__/method-signature-style.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'typescript/method-signature-style';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'method-signature-style.valid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'method-signature-style.invalid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/method-signature-style.valid.ts
+++ b/tests/oxlint/__tests__/method-signature-style.valid.ts
@@ -1,0 +1,5 @@
+interface Service {
+  connect: () => void;
+}
+
+void ({} as Service);

--- a/tests/oxlint/__tests__/no-reserved-component-names.invalid.vue
+++ b/tests/oxlint/__tests__/no-reserved-component-names.invalid.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export default {
+  name: 'div'
+};
+</script>

--- a/tests/oxlint/__tests__/no-reserved-component-names.test.ts
+++ b/tests/oxlint/__tests__/no-reserved-component-names.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'vue/no-reserved-component-names';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'no-reserved-component-names.valid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'no-reserved-component-names.invalid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/no-reserved-component-names.valid.vue
+++ b/tests/oxlint/__tests__/no-reserved-component-names.valid.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export default {
+  name: 'UserPanel'
+};
+</script>

--- a/tests/oxlint/__tests__/prefer-named-capture-group.invalid.ts
+++ b/tests/oxlint/__tests__/prefer-named-capture-group.invalid.ts
@@ -1,0 +1,3 @@
+const match = /(\d{4})-(\d{2})/u.exec('2026-06');
+
+void match;

--- a/tests/oxlint/__tests__/prefer-named-capture-group.test.ts
+++ b/tests/oxlint/__tests__/prefer-named-capture-group.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'eslint/prefer-named-capture-group';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'prefer-named-capture-group.valid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'prefer-named-capture-group.invalid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/prefer-named-capture-group.valid.ts
+++ b/tests/oxlint/__tests__/prefer-named-capture-group.valid.ts
@@ -1,0 +1,3 @@
+const match = /(?<year>\d{4})-(?<month>\d{2})/u.exec('2026-06');
+
+void match;

--- a/tests/oxlint/__tests__/require-prop-type-constructor.invalid.vue
+++ b/tests/oxlint/__tests__/require-prop-type-constructor.invalid.vue
@@ -1,0 +1,7 @@
+<script lang="ts">
+export default {
+  props: {
+    enabled: 'Boolean'
+  }
+};
+</script>

--- a/tests/oxlint/__tests__/require-prop-type-constructor.test.ts
+++ b/tests/oxlint/__tests__/require-prop-type-constructor.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'vue/require-prop-type-constructor';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'require-prop-type-constructor.valid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'require-prop-type-constructor.invalid.vue')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/require-prop-type-constructor.valid.vue
+++ b/tests/oxlint/__tests__/require-prop-type-constructor.valid.vue
@@ -1,0 +1,7 @@
+<script lang="ts">
+export default {
+  props: {
+    enabled: Boolean
+  }
+};
+</script>

--- a/tests/oxlint/__tests__/require-yields-description.invalid.ts
+++ b/tests/oxlint/__tests__/require-yields-description.invalid.ts
@@ -1,0 +1,8 @@
+/**
+ * @yields {string}
+ */
+function* createValues() {
+  yield 'value';
+}
+
+void createValues;

--- a/tests/oxlint/__tests__/require-yields-description.test.ts
+++ b/tests/oxlint/__tests__/require-yields-description.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runOxlint, violationsOf } from '../helper.js';
+
+const RULE_ID = 'jsdoc/require-yields-description';
+
+describe(RULE_ID, () => {
+  it('valid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'require-yields-description.valid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID)).toHaveLength(0);
+  });
+
+  it('invalid', async () => {
+    const diagnostics = await runOxlint([
+      path.join(import.meta.dirname, 'require-yields-description.invalid.ts')
+    ]);
+
+    expect(violationsOf(diagnostics, RULE_ID).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/oxlint/__tests__/require-yields-description.valid.ts
+++ b/tests/oxlint/__tests__/require-yields-description.valid.ts
@@ -1,0 +1,8 @@
+/**
+ * @yields {string} The next value from the sequence.
+ */
+function* createValues() {
+  yield 'value';
+}
+
+void createValues;

--- a/tests/oxlint/__tests__/split-vitest-rules.test.ts
+++ b/tests/oxlint/__tests__/split-vitest-rules.test.ts
@@ -8,6 +8,10 @@ const NON_TEST_SCOPE_FIXTURE = path.join(import.meta.dirname, '../vitest-scope.f
 
 const cases = [
   {
+    ruleId: 'vitest/consistent-test-it',
+    invalidFixture: 'consistent-test-it.invalid.ts'
+  },
+  {
     ruleId: 'vitest/no-standalone-expect',
     invalidFixture: 'no-standalone-expect.invalid.ts'
   },


### PR DESCRIPTION
## Summary

Pulled the repo onto oxlint 1.68.0 and wired up the new rule coverage so the shared config stays aligned with what oxlint can actually enforce now 😎⚙️

- ✨ Enabled `eslint/prefer-named-capture-group`, `jsdoc/require-yields-description`, `typescript/method-signature-style`, `vue/component-definition-name-casing`, `vue/no-reserved-component-names`, `vue/require-prop-type-constructor`, and `vitest/consistent-test-it` in the oxlint configs
- ♻️ Turned off the overlapping ESLint and Vue rules in the legacy configs now that oxlint owns those checks 💪
- ✅ Added focused invalid/valid fixtures plus Vitest coverage for every newly adopted rule so regressions get smoked early 🧪🔥
- 📚 Tightened the `oxlint-changelog` skill guidance so new rules under already enabled plugin namespaces get treated as actionable work 🚀

## Dependency updates

- 📦 oxlint: ^1.67.0 -> ^1.68.0
